### PR TITLE
fix: make the Windows native binding loadable

### DIFF
--- a/.changeset/fix-windows-native-load.md
+++ b/.changeset/fix-windows-native-load.md
@@ -1,0 +1,7 @@
+---
+"@gpuix/native": patch
+---
+
+Delay-load GPUI's prompt and jump-list DLL imports so Node and Bun can load the Windows native binding.
+
+Fixes #1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,13 @@ jobs:
         run: ${{ matrix.settings.build }}
         shell: bash
 
+      - name: Smoke-test Windows native load
+        if: matrix.settings.target == 'x86_64-pc-windows-msvc'
+        run: |
+          node -e "require('./index.js'); console.log('Node loaded the Windows native binding')"
+          bun -e "require('./index.js'); console.log('Bun loaded the Windows native binding')"
+        shell: bash
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/packages/native/build.rs
+++ b/packages/native/build.rs
@@ -2,4 +2,17 @@ extern crate napi_build;
 
 fn main() {
     napi_build::setup();
+
+    if matches!(
+        std::env::var("CARGO_CFG_TARGET_OS").as_deref(),
+        Ok("windows")
+    ) {
+        // GPUI links these APIs for prompts and jump lists, but GPUIX does not
+        // expose either feature. Loading them eagerly prevents Node and Bun
+        // from loading the addon when their process activation context or ICU
+        // installation does not provide the expected exports.
+        println!("cargo:rustc-cdylib-link-arg=/DELAYLOAD:comctl32.dll");
+        println!("cargo:rustc-cdylib-link-arg=/DELAYLOAD:icuuc.dll");
+        println!("cargo:rustc-link-lib=delayimp");
+    }
 }


### PR DESCRIPTION
The Windows package does contain the `.node` file. The failure happens earlier: Windows cannot finish loading it.

The addon imports `TaskDialogIndirect` from `comctl32.dll` and `u_strlen` from `icuuc.dll` as soon as the DLL is loaded. GPUIX does not expose the prompt and jump-list paths that use those functions, so loading them eagerly only makes the addon fragile inside Node and Bun.

This change delay-loads both DLLs and links `delayimp`. I also added a Windows x64 smoke check that requires the freshly built package with both Node and Bun. The existing build job only proved that the binary linked; it did not prove that a user process could load it.

I checked the build script output locally and verified that both `/DELAYLOAD` flags and `delayimp` are passed to the Windows linker. The new CI step is the final runtime check.

Fixes #1.