### PR TITLE
refactor: deepen custom element lifecycle

### DIFF
--- a/.changeset/deepen-custom-element-lifecycle.md
+++ b/.changeset/deepen-custom-element-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@gpuix/native": patch
+---
+
+Synchronize custom-element props only when retained values change, avoiding repeated parsing and allocation on every frame.

--- a/packages/native/src/custom_elements/anchored.rs
+++ b/packages/native/src/custom_elements/anchored.rs
@@ -384,7 +384,7 @@ impl CustomElement for AnchoredElement {
         }
     }
 
-    fn supported_props(&self) -> &[&str] {
+    fn supported_props(&self) -> &'static [&'static str] {
         &[
             "position",
             "side",
@@ -400,61 +400,7 @@ impl CustomElement for AnchoredElement {
         ]
     }
 
-    fn get_prop(&self, key: &str) -> Option<serde_json::Value> {
-        match key {
-            "position" => self
-                .position
-                .map(|(x, y)| serde_json::json!({ "x": x, "y": y })),
-            "side" => Some(serde_json::Value::String(
-                match self.side {
-                    Side::Top => "top",
-                    Side::Right => "right",
-                    Side::Bottom => "bottom",
-                    Side::Left => "left",
-                }
-                .to_string(),
-            )),
-            "align" => Some(serde_json::Value::String(
-                match self.align {
-                    Alignment::Start => "start",
-                    Alignment::Center => "center",
-                    Alignment::End => "end",
-                }
-                .to_string(),
-            )),
-            "anchor" => self.anchor.map(|anchor| {
-                serde_json::Value::String(
-                    match anchor {
-                        AnchorPoint::TopLeft => "topLeft",
-                        AnchorPoint::TopCenter => "topCenter",
-                        AnchorPoint::TopRight => "topRight",
-                        AnchorPoint::RightCenter => "rightCenter",
-                        AnchorPoint::BottomRight => "bottomRight",
-                        AnchorPoint::BottomCenter => "bottomCenter",
-                        AnchorPoint::BottomLeft => "bottomLeft",
-                        AnchorPoint::LeftCenter => "leftCenter",
-                    }
-                    .to_string(),
-                )
-            }),
-            "gap" => Some(serde_json::Value::from(self.gap)),
-            "offset" => Some(serde_json::json!({ "x": self.offset.0, "y": self.offset.1 })),
-            "fit" => Some(serde_json::Value::String(
-                match self.fit {
-                    FitMode::Switch => "switch",
-                    FitMode::Snap => "snap",
-                }
-                .to_string(),
-            )),
-            "snapMargin" => Some(serde_json::Value::from(self.snap_margin)),
-            "deferred" => Some(serde_json::Value::Bool(self.deferred)),
-            "priority" => Some(serde_json::Value::from(self.priority as u64)),
-            "occlude" => Some(serde_json::Value::Bool(self.occlude)),
-            _ => None,
-        }
-    }
-
-    fn supported_events(&self) -> &[&str] {
+    fn supported_events(&self) -> &'static [&'static str] {
         &[]
     }
 

--- a/packages/native/src/custom_elements/code.rs
+++ b/packages/native/src/custom_elements/code.rs
@@ -207,7 +207,7 @@ impl CustomElement for CodeElement {
         }
     }
 
-    fn supported_props(&self) -> &[&str] {
+    fn supported_props(&self) -> &'static [&'static str] {
         &[
             "code",
             "language",
@@ -218,19 +218,7 @@ impl CustomElement for CodeElement {
         ]
     }
 
-    fn get_prop(&self, key: &str) -> Option<serde_json::Value> {
-        match key {
-            "code" => Some(serde_json::Value::String(self.code.clone())),
-            "language" => self
-                .language
-                .clone()
-                .map(serde_json::Value::String)
-                .or(Some(serde_json::Value::Null)),
-            _ => None,
-        }
-    }
-
-    fn supported_events(&self) -> &[&str] {
+    fn supported_events(&self) -> &'static [&'static str] {
         &["click", "mouseEnter", "mouseLeave"]
     }
 
@@ -249,7 +237,7 @@ pub(crate) fn wire_standard_events(
     use gpui::prelude::*;
 
     let id = ctx.id;
-    for event in ctx.events {
+    for event in &ctx.events {
         let callback = ctx.event_callback.clone();
         match event.as_str() {
             "click" => {

--- a/packages/native/src/custom_elements/code.rs
+++ b/packages/native/src/custom_elements/code.rs
@@ -237,7 +237,7 @@ pub(crate) fn wire_standard_events(
     use gpui::prelude::*;
 
     let id = ctx.id;
-    for event in &ctx.events {
+    for event in ctx.events {
         let callback = ctx.event_callback.clone();
         match event.as_str() {
             "click" => {

--- a/packages/native/src/custom_elements/diff.rs
+++ b/packages/native/src/custom_elements/diff.rs
@@ -405,7 +405,7 @@ impl CustomElement for DiffElement {
         }
     }
 
-    fn supported_props(&self) -> &[&str] {
+    fn supported_props(&self) -> &'static [&'static str] {
         &[
             "patch",
             "wordDiff",
@@ -416,14 +416,7 @@ impl CustomElement for DiffElement {
         ]
     }
 
-    fn get_prop(&self, key: &str) -> Option<serde_json::Value> {
-        match key {
-            "patch" => Some(serde_json::Value::String(self.patch.clone())),
-            _ => None,
-        }
-    }
-
-    fn supported_events(&self) -> &[&str] {
+    fn supported_events(&self) -> &'static [&'static str] {
         &[
             "toggleFile",
             "showMore",

--- a/packages/native/src/custom_elements/img.rs
+++ b/packages/native/src/custom_elements/img.rs
@@ -134,28 +134,11 @@ impl CustomElement for ImgElement {
         }
     }
 
-    fn supported_props(&self) -> &[&str] {
+    fn supported_props(&self) -> &'static [&'static str] {
         &["src", "objectFit"]
     }
 
-    fn get_prop(&self, key: &str) -> Option<serde_json::Value> {
-        match key {
-            "src" => Some(serde_json::Value::String(self.src.clone())),
-            "objectFit" => Some(serde_json::Value::String(
-                match self.object_fit {
-                    ImgObjectFit::Fill => "fill",
-                    ImgObjectFit::Contain => "contain",
-                    ImgObjectFit::Cover => "cover",
-                    ImgObjectFit::ScaleDown => "scaleDown",
-                    ImgObjectFit::None => "none",
-                }
-                .to_string(),
-            )),
-            _ => None,
-        }
-    }
-
-    fn supported_events(&self) -> &[&str] {
+    fn supported_events(&self) -> &'static [&'static str] {
         &[]
     }
 
@@ -243,15 +226,11 @@ impl CustomElement for SvgElement {
         }
     }
 
-    fn supported_props(&self) -> &[&str] {
+    fn supported_props(&self) -> &'static [&'static str] {
         &["src"]
     }
 
-    fn get_prop(&self, key: &str) -> Option<serde_json::Value> {
-        (key == "src").then(|| serde_json::Value::String(self.src.clone()))
-    }
-
-    fn supported_events(&self) -> &[&str] {
+    fn supported_events(&self) -> &'static [&'static str] {
         &[]
     }
 

--- a/packages/native/src/custom_elements/input.rs
+++ b/packages/native/src/custom_elements/input.rs
@@ -344,7 +344,7 @@ impl CustomElement for TextEditorElement {
         }
     }
 
-    fn supported_props(&self) -> &[&str] {
+    fn supported_props(&self) -> &'static [&'static str] {
         &[
             "value",
             "placeholder",
@@ -355,18 +355,7 @@ impl CustomElement for TextEditorElement {
         ]
     }
 
-    fn get_prop(&self, key: &str) -> Option<serde_json::Value> {
-        match key {
-            "value" => Some(self.value.clone().into()),
-            "placeholder" => Some(self.placeholder.clone().into()),
-            "readOnly" => Some(self.read_only.into()),
-            "minRows" => Some(self.min_rows.into()),
-            "maxRows" => Some(self.max_rows.into()),
-            _ => None,
-        }
-    }
-
-    fn supported_events(&self) -> &[&str] {
+    fn supported_events(&self) -> &'static [&'static str] {
         &[
             "change", "submit", "click", "keyDown", "keyUp", "focus", "blur",
         ]

--- a/packages/native/src/custom_elements/markdown.rs
+++ b/packages/native/src/custom_elements/markdown.rs
@@ -132,18 +132,11 @@ impl CustomElement for MarkdownElement {
         }
     }
 
-    fn supported_props(&self) -> &[&str] {
+    fn supported_props(&self) -> &'static [&'static str] {
         &["source", "theme"]
     }
 
-    fn get_prop(&self, key: &str) -> Option<serde_json::Value> {
-        match key {
-            "source" => Some(serde_json::Value::String(self.source.clone())),
-            _ => None,
-        }
-    }
-
-    fn supported_events(&self) -> &[&str] {
+    fn supported_events(&self) -> &'static [&'static str] {
         &["linkClick", "click", "mouseEnter", "mouseLeave"]
     }
 

--- a/packages/native/src/custom_elements/mod.rs
+++ b/packages/native/src/custom_elements/mod.rs
@@ -28,8 +28,8 @@ pub mod markdown;
 pub struct CustomRenderContext<'a> {
     /// Numeric element ID (matches React's instance ID).
     pub id: u64,
-    /// Event types this adapter declared support for.
-    pub events: HashSet<String>,
+    /// Event types registered by React (e.g. "keyDown", "click").
+    pub events: &'a HashSet<String>,
     /// Callback for emitting events back to JS.
     pub event_callback: &'a Option<EventCallback>,
     /// Pre-created FocusHandle for this element (if it has keyboard/focus listeners).
@@ -135,7 +135,7 @@ struct CustomElementEntry {
 }
 
 impl CustomElementEntry {
-    fn sync(&mut self, props: &HashMap<String, serde_json::Value>, events: &mut HashSet<String>) {
+    fn sync(&mut self, props: &HashMap<String, serde_json::Value>) {
         let supported_props = self.element.supported_props();
         for &key in supported_props {
             let value = props.get(key).cloned().unwrap_or(serde_json::Value::Null);
@@ -164,9 +164,6 @@ impl CustomElementEntry {
             self.element.set_prop(&key, serde_json::Value::Null);
             self.applied_props.remove(&key);
         }
-
-        let supported_events = self.element.supported_events();
-        events.retain(|event| supported_events.contains(&event.as_str()));
     }
 }
 
@@ -232,7 +229,7 @@ impl CustomElementRegistry {
         &mut self,
         element_type: &str,
         props: &HashMap<String, serde_json::Value>,
-        mut ctx: CustomRenderContext,
+        ctx: CustomRenderContext,
         window: &mut gpui::Window,
         cx: &mut gpui::Context<crate::renderer::GpuixView>,
     ) -> gpui::AnyElement {
@@ -243,7 +240,18 @@ impl CustomElementRegistry {
             return gpui::Empty.into_any_element();
         };
 
-        entry.sync(props, &mut ctx.events);
+        entry.sync(props);
+        let supported = entry.element.supported_events();
+        let filtered: HashSet<String> = ctx
+            .events
+            .iter()
+            .filter(|event| supported.contains(&event.as_str()))
+            .cloned()
+            .collect();
+        let ctx = CustomRenderContext {
+            events: &filtered,
+            ..ctx
+        };
         entry.element.render(ctx, window, cx)
     }
 
@@ -346,10 +354,7 @@ mod tests {
             ("source".to_string(), serde_json::json!("first")),
             ("future".to_string(), serde_json::json!(true)),
         ]);
-        let events = HashSet::from(["click".to_string(), "change".to_string()]);
-        let mut filtered = events.clone();
-        entry.sync(&props, &mut filtered);
-        assert_eq!(filtered, HashSet::from(["click".to_string()]));
+        entry.sync(&props);
         assert_eq!(
             updates.borrow().as_slice(),
             [
@@ -358,10 +363,10 @@ mod tests {
             ]
         );
 
-        entry.sync(&props, &mut events.clone());
+        entry.sync(&props);
         assert_eq!(updates.borrow().len(), 2);
 
-        entry.sync(&HashMap::new(), &mut events.clone());
+        entry.sync(&HashMap::new());
         assert_eq!(
             updates.borrow().as_slice(),
             [

--- a/packages/native/src/custom_elements/mod.rs
+++ b/packages/native/src/custom_elements/mod.rs
@@ -28,8 +28,8 @@ pub mod markdown;
 pub struct CustomRenderContext<'a> {
     /// Numeric element ID (matches React's instance ID).
     pub id: u64,
-    /// Event types registered by React (e.g. "keyDown", "click").
-    pub events: &'a HashSet<String>,
+    /// Event types this adapter declared support for.
+    pub events: HashSet<String>,
     /// Callback for emitting events back to JS.
     pub event_callback: &'a Option<EventCallback>,
     /// Pre-created FocusHandle for this element (if it has keyboard/focus listeners).
@@ -89,7 +89,7 @@ impl CustomRenderContext<'_> {
 ///
 /// Lifecycle:
 ///   1. Factory creates instance via CustomElementFactory::create()
-///   2. React sends props via set_prop() (called each GPUI frame before render)
+///   2. Registry synchronizes changed props and declared event capabilities
 ///   3. Each GPUI frame calls render() → returns AnyElement
 ///   4. React unmounts → destroy() for cleanup
 pub trait CustomElement: 'static {
@@ -102,18 +102,14 @@ pub trait CustomElement: 'static {
         cx: &mut gpui::Context<crate::renderer::GpuixView>,
     ) -> gpui::AnyElement;
 
-    /// Set a named prop from JS. Values are JSON-encoded.
-    /// Called when React updates props on this element.
+    /// Apply a changed prop from the retained tree. Removed props arrive as null.
     fn set_prop(&mut self, key: &str, value: serde_json::Value);
 
-    /// Return known prop keys. Missing keys are reset to null/default each frame.
-    fn supported_props(&self) -> &[&str];
+    /// Immutable prop capability declaration for this adapter.
+    fn supported_props(&self) -> &'static [&'static str];
 
-    /// Read a prop value back to JS. Returns None if prop doesn't exist.
-    fn get_prop(&self, key: &str) -> Option<serde_json::Value>;
-
-    /// Return which event types this element can emit.
-    fn supported_events(&self) -> &[&str];
+    /// Immutable event capability declaration for this adapter.
+    fn supported_events(&self) -> &'static [&'static str];
 
     /// Clean up resources (GPUI entities, subscriptions, etc.)
     fn destroy(&mut self);
@@ -131,10 +127,53 @@ pub trait CustomElementFactory: 'static {
 
 // ── Registry ─────────────────────────────────────────────────────────
 
-/// Stores factories (one per type) and live instances (one per element ID).
+/// Stores one custom adapter together with the state already synchronized into it.
+struct CustomElementEntry {
+    element_type: String,
+    element: Box<dyn CustomElement>,
+    applied_props: HashMap<String, serde_json::Value>,
+}
+
+impl CustomElementEntry {
+    fn sync(&mut self, props: &HashMap<String, serde_json::Value>, events: &mut HashSet<String>) {
+        let supported_props = self.element.supported_props();
+        for &key in supported_props {
+            let value = props.get(key).cloned().unwrap_or(serde_json::Value::Null);
+            if self.applied_props.get(key) != Some(&value) {
+                self.element.set_prop(key, value.clone());
+                self.applied_props.insert(key.to_string(), value);
+            }
+        }
+
+        for (key, value) in props {
+            if supported_props.contains(&key.as_str()) || self.applied_props.get(key) == Some(value)
+            {
+                continue;
+            }
+            self.element.set_prop(key, value.clone());
+            self.applied_props.insert(key.clone(), value.clone());
+        }
+
+        let removed_unknown: Vec<String> = self
+            .applied_props
+            .keys()
+            .filter(|key| !supported_props.contains(&key.as_str()) && !props.contains_key(*key))
+            .cloned()
+            .collect();
+        for key in removed_unknown {
+            self.element.set_prop(&key, serde_json::Value::Null);
+            self.applied_props.remove(&key);
+        }
+
+        let supported_events = self.element.supported_events();
+        events.retain(|event| supported_events.contains(&event.as_str()));
+    }
+}
+
+/// Stores factories (one per type) and live adapters (one per element ID).
 pub struct CustomElementRegistry {
     factories: HashMap<String, Box<dyn CustomElementFactory>>,
-    instances: HashMap<u64, Box<dyn CustomElement>>,
+    instances: HashMap<u64, CustomElementEntry>,
 }
 
 impl CustomElementRegistry {
@@ -164,25 +203,54 @@ impl CustomElementRegistry {
             .insert(factory.element_type().to_string(), factory);
     }
 
-    /// Get an existing instance or create one via the factory.
-    /// Returns None if no factory is registered for this element type.
-    pub fn get_or_create(
-        &mut self,
-        id: u64,
-        element_type: &str,
-    ) -> Option<&mut Box<dyn CustomElement>> {
-        if !self.instances.contains_key(&id) {
-            let factory = self.factories.get(element_type)?;
-            let instance = factory.create(id);
-            self.instances.insert(id, instance);
+    /// Get an existing adapter or create one via the registered factory.
+    /// Reusing an ID for another type destroys the old adapter first.
+    fn get_or_create(&mut self, id: u64, element_type: &str) -> Option<&mut CustomElementEntry> {
+        if self
+            .instances
+            .get(&id)
+            .is_some_and(|entry| entry.element_type != element_type)
+        {
+            self.destroy(id);
         }
-        self.instances.get_mut(&id)
+
+        match self.instances.entry(id) {
+            std::collections::hash_map::Entry::Occupied(entry) => Some(entry.into_mut()),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let factory = self.factories.get(element_type)?;
+                Some(entry.insert(CustomElementEntry {
+                    element_type: element_type.to_string(),
+                    element: factory.create(id),
+                    applied_props: HashMap::new(),
+                }))
+            }
+        }
+    }
+
+    /// Synchronize one retained frame into an adapter and render it.
+    pub fn render(
+        &mut self,
+        element_type: &str,
+        props: &HashMap<String, serde_json::Value>,
+        mut ctx: CustomRenderContext,
+        window: &mut gpui::Window,
+        cx: &mut gpui::Context<crate::renderer::GpuixView>,
+    ) -> gpui::AnyElement {
+        use gpui::IntoElement;
+
+        let Some(entry) = self.get_or_create(ctx.id, element_type) else {
+            log::warn!("Unknown element type: {element_type}");
+            return gpui::Empty.into_any_element();
+        };
+
+        entry.sync(props, &mut ctx.events);
+        entry.element.render(ctx, window, cx)
     }
 
     /// Called when React destroys an element.
     pub fn destroy(&mut self, id: u64) {
-        if let Some(mut el) = self.instances.remove(&id) {
-            el.destroy();
+        if let Some(mut entry) = self.instances.remove(&id) {
+            entry.element.destroy();
         }
     }
 
@@ -202,9 +270,124 @@ impl CustomElementRegistry {
             self.destroy(id);
         }
     }
+}
 
-    /// Check if a type name has a registered factory.
-    pub fn is_custom_type(&self, element_type: &str) -> bool {
-        self.factories.contains_key(element_type)
+#[cfg(test)]
+mod tests {
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    use super::*;
+
+    struct RecordingElement {
+        updates: Rc<RefCell<Vec<(String, serde_json::Value)>>>,
+        destroyed: Rc<Cell<usize>>,
+    }
+
+    impl CustomElement for RecordingElement {
+        fn render(
+            &mut self,
+            _ctx: CustomRenderContext,
+            _window: &mut gpui::Window,
+            _cx: &mut gpui::Context<crate::renderer::GpuixView>,
+        ) -> gpui::AnyElement {
+            unreachable!("prop synchronization does not render")
+        }
+
+        fn set_prop(&mut self, key: &str, value: serde_json::Value) {
+            self.updates.borrow_mut().push((key.to_string(), value));
+        }
+
+        fn supported_props(&self) -> &'static [&'static str] {
+            &["source"]
+        }
+
+        fn supported_events(&self) -> &'static [&'static str] {
+            &["click"]
+        }
+
+        fn destroy(&mut self) {
+            self.destroyed.set(self.destroyed.get() + 1);
+        }
+    }
+
+    struct RecordingFactory {
+        element_type: &'static str,
+        updates: Rc<RefCell<Vec<(String, serde_json::Value)>>>,
+        destroyed: Rc<Cell<usize>>,
+    }
+
+    impl CustomElementFactory for RecordingFactory {
+        fn element_type(&self) -> &str {
+            self.element_type
+        }
+
+        fn create(&self, _id: u64) -> Box<dyn CustomElement> {
+            Box::new(RecordingElement {
+                updates: self.updates.clone(),
+                destroyed: self.destroyed.clone(),
+            })
+        }
+    }
+
+    #[test]
+    fn sync_applies_only_changes_and_resets_removed_unknown_props() {
+        let updates = Rc::new(RefCell::new(Vec::new()));
+        let destroyed = Rc::new(Cell::new(0));
+        let mut entry = CustomElementEntry {
+            element_type: "recording".to_string(),
+            element: Box::new(RecordingElement {
+                updates: updates.clone(),
+                destroyed,
+            }),
+            applied_props: HashMap::new(),
+        };
+        let props = HashMap::from([
+            ("source".to_string(), serde_json::json!("first")),
+            ("future".to_string(), serde_json::json!(true)),
+        ]);
+        let events = HashSet::from(["click".to_string(), "change".to_string()]);
+        let mut filtered = events.clone();
+        entry.sync(&props, &mut filtered);
+        assert_eq!(filtered, HashSet::from(["click".to_string()]));
+        assert_eq!(
+            updates.borrow().as_slice(),
+            [
+                ("source".to_string(), serde_json::json!("first")),
+                ("future".to_string(), serde_json::json!(true)),
+            ]
+        );
+
+        entry.sync(&props, &mut events.clone());
+        assert_eq!(updates.borrow().len(), 2);
+
+        entry.sync(&HashMap::new(), &mut events.clone());
+        assert_eq!(
+            updates.borrow().as_slice(),
+            [
+                ("source".to_string(), serde_json::json!("first")),
+                ("future".to_string(), serde_json::json!(true)),
+                ("source".to_string(), serde_json::Value::Null),
+                ("future".to_string(), serde_json::Value::Null),
+            ]
+        );
+    }
+
+    #[test]
+    fn reusing_an_id_for_another_type_destroys_the_previous_adapter() {
+        let updates = Rc::new(RefCell::new(Vec::new()));
+        let destroyed = Rc::new(Cell::new(0));
+        let mut registry = CustomElementRegistry::new();
+        for element_type in ["first", "second"] {
+            registry.register(Box::new(RecordingFactory {
+                element_type,
+                updates: updates.clone(),
+                destroyed: destroyed.clone(),
+            }));
+        }
+
+        assert!(registry.get_or_create(42, "first").is_some());
+        assert!(registry.get_or_create(42, "second").is_some());
+        assert_eq!(destroyed.get(), 1);
     }
 }

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -1986,75 +1986,32 @@ pub(crate) fn build_element(
 
         // Polymorphic dispatch for all custom elements.
         custom_type => {
-            let child_ids: Vec<u64> = element
+            let custom_children: Vec<gpui::AnyElement> = element
                 .children
                 .iter()
                 .copied()
                 .filter(|child_id| ctx.tree.elements.contains_key(child_id))
-                .collect();
-            let custom_children: Vec<gpui::AnyElement> = child_ids
-                .into_iter()
                 .map(|child_id| build_element(child_id, ctx, window, cx))
                 .collect();
-
-            let selection = ctx.selection.clone();
             let inherited = ctx.inherited;
-            let custom_registry = &mut *ctx.custom_registry;
-            if let Some(instance) = custom_registry.get_or_create(id, custom_type) {
-                // Sync known props from RetainedElement to the CustomElement instance.
-                // Missing keys are explicitly reset with null to avoid stale state.
-                let supported_props: Vec<String> = instance
-                    .supported_props()
-                    .iter()
-                    .map(|key| (*key).to_string())
-                    .collect();
-
-                for key in &supported_props {
-                    let value = element
-                        .custom_props
-                        .get(key)
-                        .cloned()
-                        .unwrap_or(serde_json::Value::Null);
-                    instance.set_prop(key, value);
-                }
-
-                // Also pass through unknown props for forward compatibility.
-                for (key, value) in &element.custom_props {
-                    if !supported_props.iter().any(|known| known == key) {
-                        instance.set_prop(key, value.clone());
-                    }
-                }
-
-                // Only pass events the custom element declares support for.
-                let supported_events: Vec<String> = instance
-                    .supported_events()
-                    .iter()
-                    .map(|event| (*event).to_string())
-                    .collect();
-                let filtered_events: HashSet<String> = element
-                    .events
-                    .iter()
-                    .filter(|event| supported_events.iter().any(|supported| supported == *event))
-                    .cloned()
-                    .collect();
-
-                let render_ctx = CustomRenderContext {
-                    id,
-                    events: &filtered_events,
-                    event_callback: ctx.event_callback,
-                    focus_handle: ctx.focus_handles.get(&id),
-                    style,
-                    children: custom_children,
-                    selection,
-                    selectable: inherited.selectable,
-                    selection_wash: inherited.selection_wash,
-                };
-
-                instance.render(render_ctx, window, cx)
-            } else {
-                log::warn!("Unknown element type: {}", custom_type);
-                gpui::Empty.into_any_element()
-            }
+            let render_ctx = CustomRenderContext {
+                id,
+                events: element.events.clone(),
+                event_callback: ctx.event_callback,
+                focus_handle: ctx.focus_handles.get(&id),
+                style,
+                children: custom_children,
+                selection: ctx.selection.clone(),
+                selectable: inherited.selectable,
+                selection_wash: inherited.selection_wash,
+            };
+            ctx.custom_registry.render(
+                custom_type,
+                &element.custom_props,
+                render_ctx,
+                window,
+                cx,
+            )
         }
     };
 

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -1996,7 +1996,7 @@ pub(crate) fn build_element(
             let inherited = ctx.inherited;
             let render_ctx = CustomRenderContext {
                 id,
-                events: element.events.clone(),
+                events: &element.events,
                 event_callback: ctx.event_callback,
                 focus_handle: ctx.focus_handles.get(&id),
                 style,


### PR DESCRIPTION
Every GPUI frame was rebuilding custom-element plumbing in `renderer.rs`: copy the capability lists into new `String` vectors, resend every prop, scan those lists again to filter events, then call the adapter. That was especially wasteful for code, markdown, diff, and theme props because `set_prop` can parse or rebuild native state.

The registry now owns that lifecycle. It creates the adapter, remembers which type owns an element ID, applies only changed props, clears removed unknown props, filters events, and finally renders. Reusing an ID for another custom-element type destroys the old adapter before creating the new one.

Capability lists are static slices now, so the frame path no longer allocates strings for them. I also removed `get_prop` from the trait and all adapters: nothing called it, and keeping it made every implementation carry a hypothetical interface.

Two Rust tests cover the parts that are easy to regress: unchanged props are not resent, removed props are reset, unsupported events are filtered, and an ID changing adapter type destroys the old instance.

`cargo check --lib` passes, as do the two focused Rust tests.

This is stacked on #4; the custom-element commit is `fe9ea0a`.