### PR TITLE
fix: enforce one automation session lifecycle

### DIFF
--- a/.changeset/harden-automation-session.md
+++ b/.changeset/harden-automation-session.md
@@ -1,0 +1,5 @@
+---
+"@gpuix/react": patch
+---
+
+Reject automation calls after close and make session shutdown idempotent across in-process and SSE backends.

--- a/packages/react/src/__tests__/automation-stdio.test.ts
+++ b/packages/react/src/__tests__/automation-stdio.test.ts
@@ -7,6 +7,7 @@ import {
   handleAutomationRequest,
   InProcessBackend,
   PROTOCOL_VERSION,
+  SseBackend,
 } from "../automation/index.js"
 import type { TestAutomationRenderer } from "../automation/client.js"
 
@@ -86,5 +87,51 @@ describe("automation stdio", () => {
     expect(encodeSse({ id: 1, method: "blur", params: {} })).toMatch(
       /^data: \{/
     )
+  })
+
+  it("closes pending requests and the transport exactly once", async () => {
+    let closes = 0
+    const backend = new SseBackend(
+      () => {},
+      () => {},
+      async () => {
+        closes += 1
+      }
+    )
+    const pending = backend.call("blur", {})
+    const rejection = expect(pending).rejects.toMatchObject({ code: "Closed" })
+
+    await backend.close()
+    await rejection
+    await backend.close()
+
+    expect(closes).toBe(1)
+  })
+
+  it("enforces the same closed-session contract in process", async () => {
+    const backend = new InProcessBackend(fakeRenderer())
+    await backend.close()
+
+    await expect(backend.call("blur", {})).rejects.toMatchObject({
+      code: "Closed",
+    })
+  })
+
+  it("rejects calls made after the session closes without writing", async () => {
+    let writes = 0
+    const backend = new SseBackend(
+      () => {
+        writes += 1
+      },
+      () => {}
+    )
+    await backend.close()
+
+    const rejected = backend.call("blur", {}).then(
+      () => undefined,
+      (error: unknown) => error
+    )
+    expect(writes).toBe(0)
+    await expect(rejected).resolves.toMatchObject({ code: "Closed" })
   })
 })

--- a/packages/react/src/automation/client.ts
+++ b/packages/react/src/automation/client.ts
@@ -29,6 +29,35 @@ export interface AutomationBackend {
   close(): Promise<void>
 }
 
+abstract class ValidatedAutomationBackend implements AutomationBackend {
+  private closed = false
+
+  async call<M extends MethodName>(
+    method: M,
+    params: ParamsOf<M>
+  ): Promise<ResultOf<M>> {
+    if (this.closed) {
+      throw new AutomationError("Closed", "Automation session is closed")
+    }
+    const parsedParams = methods[method].params.parse(params) as ParamsOf<M>
+    const result = await this.request(method, parsedParams)
+    return methods[method].result.parse(result) as ResultOf<M>
+  }
+
+  protected closeSession(): boolean {
+    if (this.closed) return false
+    this.closed = true
+    return true
+  }
+
+  protected abstract request<M extends MethodName>(
+    method: M,
+    params: ParamsOf<M>
+  ): unknown | Promise<unknown>
+
+  abstract close(): Promise<void>
+}
+
 export interface TestAutomationRenderer {
   nativeSimulateClick(x: number, y: number): void
   nativeSimulateMouseDown(x: number, y: number, button?: number): void
@@ -69,19 +98,21 @@ type HandlerMap = {
   [M in MethodName]: (params: ParamsOf<M>) => ResultOf<M> | Promise<ResultOf<M>>
 }
 
-export class InProcessBackend implements AutomationBackend {
-  constructor(private readonly renderer: TestAutomationRenderer) {}
-
-  async call<M extends MethodName>(
-    method: M,
-    params: ParamsOf<M>
-  ): Promise<ResultOf<M>> {
-    methods[method].params.parse(params)
-    const result = await this.handlers[method](params as never)
-    return methods[method].result.parse(result) as ResultOf<M>
+export class InProcessBackend extends ValidatedAutomationBackend {
+  constructor(private readonly renderer: TestAutomationRenderer) {
+    super()
   }
 
-  async close(): Promise<void> {}
+  protected request<M extends MethodName>(
+    method: M,
+    params: ParamsOf<M>
+  ): unknown | Promise<unknown> {
+    return this.handlers[method](params as never)
+  }
+
+  async close(): Promise<void> {
+    this.closeSession()
+  }
 
   private readonly handlers: HandlerMap = {
     initialize: () => ({
@@ -186,21 +217,33 @@ export class InProcessBackend implements AutomationBackend {
   }
 }
 
-export class SseBackend implements AutomationBackend {
+class PendingAutomationResponse {
+  readonly promise: Promise<AutomationResponse>
+  readonly resolve: (response: AutomationResponse) => void
+  readonly reject: (error: unknown) => void
+
+  constructor() {
+    let resolveResponse!: (response: AutomationResponse) => void
+    let rejectResponse!: (error: unknown) => void
+    this.promise = new Promise<AutomationResponse>((resolve, reject) => {
+      resolveResponse = resolve
+      rejectResponse = reject
+    })
+    this.resolve = resolveResponse
+    this.reject = rejectResponse
+  }
+}
+
+export class SseBackend extends ValidatedAutomationBackend {
   private nextId = 1
-  private readonly pending = new Map<
-    number,
-    {
-      resolve: (response: AutomationResponse) => void
-      reject: (error: unknown) => void
-    }
-  >()
+  private readonly pending = new Map<number, PendingAutomationResponse>()
 
   constructor(
     private readonly write: (chunk: string) => void,
     feed: (listener: (chunk: string) => void) => void,
     private readonly onClose?: () => Promise<void>
   ) {
+    super()
     const decoder = createSseDecoder((message) => {
       if ("method" in message) return
       if ("event" in message) return
@@ -212,17 +255,22 @@ export class SseBackend implements AutomationBackend {
     feed((chunk) => decoder.feed(chunk))
   }
 
-  async call<M extends MethodName>(
+  protected async request<M extends MethodName>(
     method: M,
     params: ParamsOf<M>
-  ): Promise<ResultOf<M>> {
-    methods[method].params.parse(params)
+  ): Promise<unknown> {
     const id = this.nextId++
     const request = { id, method, params } as AutomationRequest
-    const response = await new Promise<AutomationResponse>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject })
+    const pending = new PendingAutomationResponse()
+    this.pending.set(id, pending)
+    try {
       this.write(encodeSse(request))
-    })
+    } catch (error) {
+      this.pending.delete(id)
+      pending.reject(error)
+    }
+
+    const response = await pending.promise
     if ("error" in response) {
       throw new AutomationError(
         response.error.code,
@@ -230,10 +278,11 @@ export class SseBackend implements AutomationBackend {
         response.error.data
       )
     }
-    return methods[method].result.parse(response.result) as ResultOf<M>
+    return response.result
   }
 
   async close(): Promise<void> {
+    if (!this.closeSession()) return
     for (const [id, waiter] of this.pending) {
       waiter.reject(new AutomationError("Closed", `Request ${id} cancelled`))
     }


### PR DESCRIPTION
The in-process and SSE backends looked like the same automation interface, but they did not quite behave like one session.

An SSE backend still accepted calls after `close()`, which wrote a request that could never receive a response. Calling `close()` twice ran the transport cleanup twice. The in-process backend kept accepting calls after close as well. Validation was also repeated independently in both adapters.

A shared backend module now owns validation and the open/closed state. Both adapters reject calls after close in the same way. SSE shutdown is idempotent, rejects pending requests once, and removes a request from the pending map if writing it fails.

The implementation deliberately stays on ES2022 rather than using newer Promise helpers, because the package still advertises Node 18 support.

The protocol and stdio tests now include the close cases and all 11 focused tests pass, along with the TypeScript build.

This is stacked on #5; the automation commit is `cbcdbd9`.