### PR TITLE
ci: run the test commands the packages actually define

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,17 @@ jobs:
           name: bindings-aarch64-apple-darwin
           path: packages/native/
 
-      - name: Run tests
-        run: bun test
+      - name: Run React tests
+        run: bun run test
         working-directory: packages/react
+
+      - name: Build React package
+        run: bun run build
+        working-directory: packages/react
+
+      - name: Run example tests
+        run: bun run test
+        working-directory: examples
 
   test-windows:
     name: test-windows-load


### PR DESCRIPTION
The test job was bypassing the React package script with `bun test`. The suite is written for Vitest, and the repository's own contributor guide explicitly calls `bun run test` the canonical command.

The examples were not checked at all. They exercise the chat and diff compositions users are most likely to copy, but they also import the built React package, so CI needs to compile `@gpuix/react` before running them.

The macOS test job now does the same sequence a contributor should use: run the React Vitest suite, build the package, then run the example Vitest suite. The downloaded GPU-backed native artifact remains the one shared by all three steps.

I parsed the workflow locally, ran the React build, and confirmed that Vitest discovers both example suites. Their GPU tests skip on Linux as expected; the existing macOS job is where they will execute against `TestGpuixRenderer`.