### PR TITLE
feat: make live automation usable on threaded platforms

### DIFF
--- a/.changeset/enable-live-mouse-all-platforms.md
+++ b/.changeset/enable-live-mouse-all-platforms.md
@@ -1,0 +1,5 @@
+---
+"@gpuix/native": patch
+---
+
+Enable live-app mouse input, locator bounds, and timeline clock controls on Windows, Linux, and FreeBSD.

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -356,12 +356,22 @@ async fn run_ui_commands(
                 Ok(())
             }
             UiCommand::GetAutomationBounds { response } => {
-                response.send(crate::automation::all_bounds()).ok();
-                Ok(())
+                window.update(cx, move |_view, window, cx| {
+                    cx.notify();
+                    window.refresh();
+                    window.on_next_frame(move |_window, _cx| {
+                        response.send(crate::automation::all_bounds()).ok();
+                    });
+                })
             }
             UiCommand::GetElementBounds { id, response } => {
-                response.send(crate::automation::get_bounds(id)).ok();
-                Ok(())
+                window.update(cx, move |_view, window, cx| {
+                    cx.notify();
+                    window.refresh();
+                    window.on_next_frame(move |_window, _cx| {
+                        response.send(crate::automation::get_bounds(id)).ok();
+                    });
+                })
             }
             UiCommand::FocusElement(id) => window.update(cx, move |view, window, cx| {
                 view.reveal_virtual_list_ancestor(id);

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -125,17 +125,18 @@ pub(crate) fn debug_frame_overlay_mode_name(mode: gpui::DebugFrameOverlayMode) -
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
-fn recv_debug_frame_overlay_mode(
-    receiver: std::sync::mpsc::Receiver<String>,
-) -> Result<String> {
+fn recv_ui_response<T>(
+    receiver: std::sync::mpsc::Receiver<T>,
+    operation: &str,
+) -> Result<T> {
     match receiver.recv_timeout(Duration::from_secs(2)) {
-        Ok(mode) => Ok(mode),
-        Err(RecvTimeoutError::Timeout) => Err(Error::from_reason(
-            "Timed out after 2 seconds waiting for the debug frame overlay query",
-        )),
-        Err(RecvTimeoutError::Disconnected) => Err(Error::from_reason(
-            "The GPUI UI thread stopped during the debug frame overlay query",
-        )),
+        Ok(response) => Ok(response),
+        Err(RecvTimeoutError::Timeout) => Err(Error::from_reason(format!(
+            "Timed out after 2 seconds waiting for {operation}"
+        ))),
+        Err(RecvTimeoutError::Disconnected) => Err(Error::from_reason(format!(
+            "The GPUI UI thread stopped during {operation}"
+        ))),
     }
 }
 
@@ -169,6 +170,38 @@ fn invalidate_window() -> Result<()> {
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+enum MouseInput {
+    Click {
+        x: f64,
+        y: f64,
+        button: u32,
+    },
+    Down {
+        x: f64,
+        y: f64,
+        button: u32,
+    },
+    Up {
+        x: f64,
+        y: f64,
+        button: u32,
+    },
+    Move {
+        x: f64,
+        y: f64,
+        pressed_button: Option<u32>,
+    },
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+enum ClockControl {
+    Pause,
+    Set(f64),
+    FastForward(f64),
+    Resume,
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
 enum UiCommand {
     Invalidate,
     SetWindowTitle(String),
@@ -193,7 +226,22 @@ enum UiCommand {
         id: u64,
         response: SyncSender<Option<[f64; 2]>>,
     },
+    GetAutomationBounds {
+        response: SyncSender<HashMap<u64, crate::automation::ElementBounds>>,
+    },
+    GetElementBounds {
+        id: u64,
+        response: SyncSender<Option<crate::automation::ElementBounds>>,
+    },
     FocusElement(u64),
+    ControlClock {
+        control: ClockControl,
+        response: SyncSender<f64>,
+    },
+    DispatchMouse {
+        input: MouseInput,
+        response: SyncSender<std::result::Result<(), String>>,
+    },
     Blur,
 }
 
@@ -307,6 +355,14 @@ async fn run_ui_commands(
                 response.send(offset).ok();
                 Ok(())
             }
+            UiCommand::GetAutomationBounds { response } => {
+                response.send(crate::automation::all_bounds()).ok();
+                Ok(())
+            }
+            UiCommand::GetElementBounds { id, response } => {
+                response.send(crate::automation::get_bounds(id)).ok();
+                Ok(())
+            }
             UiCommand::FocusElement(id) => window.update(cx, move |view, window, cx| {
                 view.reveal_virtual_list_ancestor(id);
                 if let Some(handle) = view.focus_handles.get(&id) {
@@ -315,6 +371,49 @@ async fn run_ui_commands(
                 cx.notify();
                 window.refresh();
             }),
+            UiCommand::ControlClock { control, response } => {
+                window.update(cx, move |view, _window, cx| {
+                    let now_ms = match control {
+                        ClockControl::Pause => view.clock.pause(),
+                        ClockControl::Set(now_ms) => view.clock.set_ms(now_ms),
+                        ClockControl::FastForward(delta_ms) => {
+                            view.clock.fast_forward_ms(delta_ms)
+                        }
+                        ClockControl::Resume => view.clock.resume(),
+                    };
+                    cx.notify();
+                    response.send(now_ms).ok();
+                })
+            }
+            UiCommand::DispatchMouse { input, response } => {
+                let result = window.update(cx, move |_view, window, cx| match input {
+                    MouseInput::Click { x, y, button } => {
+                        crate::automation::dispatch_click(window, cx, x, y, button);
+                    }
+                    MouseInput::Down { x, y, button } => {
+                        crate::automation::dispatch_mouse_down(window, cx, x, y, button);
+                    }
+                    MouseInput::Up { x, y, button } => {
+                        crate::automation::dispatch_mouse_up(window, cx, x, y, button);
+                    }
+                    MouseInput::Move {
+                        x,
+                        y,
+                        pressed_button,
+                    } => {
+                        crate::automation::dispatch_mouse_move(window, cx, x, y, pressed_button);
+                    }
+                });
+                response
+                    .send(
+                        result
+                            .as_ref()
+                            .map(|_| ())
+                            .map_err(|error| format!("{error:#}")),
+                    )
+                    .ok();
+                result
+            }
             UiCommand::Blur => window.update(cx, |_view, window, _cx| window.blur()),
         };
         if let Err(error) = result {
@@ -365,6 +464,72 @@ impl GpuixRenderer {
             .ok_or_else(|| Error::from_reason("GPUI application is not initialized"))?
             .unbounded_send(command)
             .map_err(|_| Error::from_reason("The GPUI UI thread is not running"))
+    }
+
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+    fn dispatch_mouse_input(&self, input: MouseInput) -> Result<()> {
+        let (response_sender, response_receiver) = sync_channel(1);
+        self.send_ui_command(UiCommand::DispatchMouse {
+            input,
+            response: response_sender,
+        })?;
+        recv_ui_response(response_receiver, "the GPUI UI command")?
+            .map_err(Error::from_reason)
+    }
+
+    fn automation_bounds(
+        &self,
+    ) -> Result<HashMap<u64, crate::automation::ElementBounds>> {
+        #[cfg(target_os = "macos")]
+        return Ok(crate::automation::all_bounds());
+
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        {
+            let (response, receiver) = sync_channel(1);
+            self.send_ui_command(UiCommand::GetAutomationBounds { response })?;
+            return recv_ui_response(receiver, "the automation bounds query");
+        }
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
+        Err(Error::from_reason("Unsupported operating system"))
+    }
+
+    fn element_bounds(
+        &self,
+        id: u64,
+    ) -> Result<Option<crate::automation::ElementBounds>> {
+        #[cfg(target_os = "macos")]
+        return Ok(crate::automation::get_bounds(id));
+
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        {
+            let (response, receiver) = sync_channel(1);
+            self.send_ui_command(UiCommand::GetElementBounds { id, response })?;
+            return recv_ui_response(receiver, "the element bounds query");
+        }
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
+        {
+            let _ = id;
+            Err(Error::from_reason("Unsupported operating system"))
+        }
+    }
+
+    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+    fn control_clock(&self, control: ClockControl) -> Result<f64> {
+        let (response, receiver) = sync_channel(1);
+        self.send_ui_command(UiCommand::ControlClock { control, response })?;
+        recv_ui_response(receiver, "the automation clock command")
     }
 
     fn request_invalidate(&self) -> Result<()> {
@@ -837,7 +1002,7 @@ impl GpuixRenderer {
         {
             let (response, receiver) = sync_channel(1);
             self.send_ui_command(UiCommand::CycleDebugFrameOverlay { response })?;
-            return recv_debug_frame_overlay_mode(receiver);
+            return recv_ui_response(receiver, "the debug frame overlay query");
         }
 
         #[cfg(not(any(
@@ -864,7 +1029,7 @@ impl GpuixRenderer {
         {
             let (response, receiver) = sync_channel(1);
             self.send_ui_command(UiCommand::GetDebugFrameOverlay { response })?;
-            recv_debug_frame_overlay_mode(receiver)
+            recv_ui_response(receiver, "the debug frame overlay query")
         }
 
         #[cfg(not(any(
@@ -1091,15 +1256,10 @@ impl GpuixRenderer {
         {
             let (response, receiver) = sync_channel(1);
             self.send_ui_command(UiCommand::GetScrollOffset { id, response })?;
-            return match receiver.recv_timeout(Duration::from_secs(2)) {
-                Ok(offset) => Ok(offset.map(|[x, y]| vec![x, y])),
-                Err(RecvTimeoutError::Timeout) => Err(Error::from_reason(
-                    "Timed out after 2 seconds waiting for the GPUI scroll query",
-                )),
-                Err(RecvTimeoutError::Disconnected) => Err(Error::from_reason(
-                    "The GPUI UI thread stopped during the scroll query",
-                )),
-            };
+            return Ok(
+                recv_ui_response(receiver, "the GPUI scroll query")?
+                    .map(|[x, y]| vec![x, y]),
+            );
         }
 
         #[cfg(not(any(
@@ -1114,8 +1274,9 @@ impl GpuixRenderer {
     #[napi]
     pub fn get_automation_tree(&self) -> Result<String> {
         self.request_invalidate()?;
+        let bounds = self.automation_bounds()?;
         let tree = self.tree.lock().unwrap();
-        let json = tree.to_automation_json(&crate::automation::all_bounds());
+        let json = tree.to_automation_json(&bounds);
         serde_json::to_string(&json)
             .map_err(|e| Error::from_reason(format!("JSON serialization failed: {}", e)))
     }
@@ -1123,9 +1284,9 @@ impl GpuixRenderer {
     #[napi]
     pub fn get_element_bounds(&self, id: f64) -> Result<Option<Vec<f64>>> {
         let id = to_element_id(id)?;
-        Ok(crate::automation::get_bounds(id).map(|bounds| {
-            vec![bounds.x, bounds.y, bounds.width, bounds.height]
-        }))
+        Ok(self
+            .element_bounds(id)?
+            .map(|bounds| vec![bounds.x, bounds.y, bounds.width, bounds.height]))
     }
 
     #[napi]
@@ -1145,43 +1306,79 @@ impl GpuixRenderer {
 
     #[napi]
     pub fn simulate_click(&self, x: f64, y: f64, button: Option<u32>) -> Result<()> {
+        let button = button.unwrap_or(0);
+
         #[cfg(target_os = "macos")]
         return update_window(move |_view, window, cx| {
-            crate::automation::dispatch_click(window, cx, x, y, button.unwrap_or(0));
+            crate::automation::dispatch_click(window, cx, x, y, button);
         });
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.dispatch_mouse_input(MouseInput::Click { x, y, button });
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
         {
             let _ = (x, y, button);
-            Err(Error::from_reason("simulateClick is only implemented on macOS"))
+            Err(Error::from_reason(
+                "The production GPUIX renderer does not support this operating system",
+            ))
         }
     }
 
     #[napi]
     pub fn simulate_mouse_down(&self, x: f64, y: f64, button: Option<u32>) -> Result<()> {
+        let button = button.unwrap_or(0);
+
         #[cfg(target_os = "macos")]
         return update_window(move |_view, window, cx| {
-            crate::automation::dispatch_mouse_down(window, cx, x, y, button.unwrap_or(0));
+            crate::automation::dispatch_mouse_down(window, cx, x, y, button);
         });
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.dispatch_mouse_input(MouseInput::Down { x, y, button });
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
         {
             let _ = (x, y, button);
-            Err(Error::from_reason("simulateMouseDown is only implemented on macOS"))
+            Err(Error::from_reason(
+                "The production GPUIX renderer does not support this operating system",
+            ))
         }
     }
 
     #[napi]
     pub fn simulate_mouse_up(&self, x: f64, y: f64, button: Option<u32>) -> Result<()> {
+        let button = button.unwrap_or(0);
+
         #[cfg(target_os = "macos")]
         return update_window(move |_view, window, cx| {
-            crate::automation::dispatch_mouse_up(window, cx, x, y, button.unwrap_or(0));
+            crate::automation::dispatch_mouse_up(window, cx, x, y, button);
         });
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.dispatch_mouse_input(MouseInput::Up { x, y, button });
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
         {
             let _ = (x, y, button);
-            Err(Error::from_reason("simulateMouseUp is only implemented on macOS"))
+            Err(Error::from_reason(
+                "The production GPUIX renderer does not support this operating system",
+            ))
         }
     }
 
@@ -1197,10 +1394,24 @@ impl GpuixRenderer {
             crate::automation::dispatch_mouse_move(window, cx, x, y, pressed_button);
         });
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.dispatch_mouse_input(MouseInput::Move {
+            x,
+            y,
+            pressed_button,
+        });
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
         {
             let _ = (x, y, pressed_button);
-            Err(Error::from_reason("simulateMouseMove is only implemented on macOS"))
+            Err(Error::from_reason(
+                "The production GPUIX renderer does not support this operating system",
+            ))
         }
     }
 
@@ -1213,8 +1424,16 @@ impl GpuixRenderer {
             now_ms
         });
 
-        #[cfg(not(target_os = "macos"))]
-        Err(Error::from_reason("clockPause is only implemented on macOS"))
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.control_clock(ClockControl::Pause);
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
+        Err(Error::from_reason("Unsupported operating system"))
     }
 
     #[napi]
@@ -1226,10 +1445,18 @@ impl GpuixRenderer {
             now_ms
         });
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.control_clock(ClockControl::Set(now_ms));
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
         {
             let _ = now_ms;
-            Err(Error::from_reason("clockSet is only implemented on macOS"))
+            Err(Error::from_reason("Unsupported operating system"))
         }
     }
 
@@ -1242,12 +1469,18 @@ impl GpuixRenderer {
             now_ms
         });
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.control_clock(ClockControl::FastForward(delta_ms));
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
         {
             let _ = delta_ms;
-            Err(Error::from_reason(
-                "clockFastForward is only implemented on macOS",
-            ))
+            Err(Error::from_reason("Unsupported operating system"))
         }
     }
 
@@ -1260,8 +1493,16 @@ impl GpuixRenderer {
             now_ms
         });
 
-        #[cfg(not(target_os = "macos"))]
-        Err(Error::from_reason("clockResume is only implemented on macOS"))
+        #[cfg(any(target_os = "windows", target_os = "linux", target_os = "freebsd"))]
+        return self.control_clock(ClockControl::Resume);
+
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "freebsd"
+        )))]
+        Err(Error::from_reason("Unsupported operating system"))
     }
 
     #[napi]


### PR DESCRIPTION
Live automation exposed mouse and clock methods on every platform, but the native implementation only handled them on macOS. Linux, Windows, and FreeBSD run GPUI on a dedicated UI thread, so calling those methods there returned an error.

Locator clicks had a second problem on the threaded platforms: paint bounds are thread-local. `getElementBounds()` and `getAutomationTree()` read them from the Node thread and therefore returned no bounds even after a frame had painted.

This sends mouse input, bounds queries, and clock controls through the existing FIFO UI-command channel. Calls wait for the UI thread to finish the operation, with the same bounded two-second failure mode already used by the debug and scroll queries. The macOS path is unchanged.

This also covers the concrete cross-platform clock gap raised in #8: live apps can now pause, seek with `set()`, fast-forward, and resume on Windows and Linux. Playback speed, canvas drawing, richer motion primitives, and audio still need separate designs.

I built the Linux N-API binding and drove an actual counter app over the SSE automation transport. The smoke run resolved painted bounds, delivered mouse move/down/up/click handlers, and returned `1000 -> 1250 -> 1250` for set/fast-forward/resume. The React automation protocol tests (8 tests) and TypeScript build also pass.