### PR TITLE
Apply declared styles and add borders/shadows

### DIFF
--- a/.changeset/add-border-sides-and-shadow.md
+++ b/.changeset/add-border-sides-and-shadow.md
@@ -1,0 +1,6 @@
+---
+"@gpuix/native": minor
+"@gpuix/react": minor
+---
+
+Add per-side border widths and one structured `boxShadow` style with offset, blur, spread, and color values.

--- a/.changeset/apply-declared-layout-styles.md
+++ b/.changeset/apply-declared-layout-styles.md
@@ -1,0 +1,5 @@
+---
+"@gpuix/native": patch
+---
+
+Apply per-corner radii, `flexBasis`, and `alignContent` styles that were already declared in the public React style type.

--- a/README.md
+++ b/README.md
@@ -1218,7 +1218,7 @@ CSS-like styling via the `style` prop:
 </div>
 ```
 
-**Layout:** `display` (`"flex"` | `"grid"`), `flexDirection`, `flexWrap`, `flexGrow`, `flexShrink`, `alignItems`, `alignSelf`, `justifyContent`, `gap`, `rowGap`, `columnGap`, `gridTemplateColumns`, `gridTemplateRows`, `gridColumnMin`, `gridRowMin`
+**Layout:** `display` (`"flex"` | `"grid"`), `flexDirection`, `flexWrap`, `flexGrow`, `flexShrink`, `flexBasis`, `alignItems`, `alignSelf`, `alignContent`, `justifyContent`, `gap`, `rowGap`, `columnGap`, `gridTemplateColumns`, `gridTemplateRows`, `gridColumnMin`, `gridRowMin`
 
 **Sizing:** `width`, `height`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight` — accepts pixels (number) or percentages (string like `"100%"`)
 
@@ -1226,7 +1226,24 @@ CSS-like styling via the `style` prop:
 
 **Position:** `position` (`"relative"` | `"absolute"`), `top`, `right`, `bottom`, `left`
 
-**Visual:** `backgroundColor`, `color`, `opacity`, `cursor`, `pointerEvents`, `borderRadius`, `borderWidth`, `borderColor`
+**Visual:** `backgroundColor`, `color`, `opacity`, `cursor`, `pointerEvents`, `borderRadius`, `borderTopLeftRadius`, `borderTopRightRadius`, `borderBottomLeftRadius`, `borderBottomRightRadius`, `borderWidth`, `borderTopWidth`, `borderRightWidth`, `borderBottomWidth`, `borderLeftWidth`, `borderColor`, `boxShadow`
+
+`boxShadow` accepts one structured shadow. Its fields are `offsetX`, `offsetY`,
+`blurRadius`, `spreadRadius`, and `color`:
+
+```tsx
+<div
+  style={{
+    boxShadow: {
+      offsetX: 0,
+      offsetY: 4,
+      blurRadius: 12,
+      spreadRadius: 0,
+      color: '#00000033',
+    },
+  }}
+/>
+```
 
 **Overflow:** `overflow`, `overflowX`, `overflowY` — `"hidden"` clips content, `"scroll"` creates a native scrollable container with persistent scroll state
 

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -2612,10 +2612,24 @@ pub(crate) fn apply_styles<E: gpui::Styled>(mut el: E, style: &StyleDesc) -> E {
     if let Some(shrink) = style.flex_shrink {
         el.style().flex_shrink = Some(shrink as f32);
     }
+    if let Some(basis) = style.flex_basis {
+        el = el.flex_basis(gpui::px(basis as f32));
+    }
     match style.align_items.as_deref() {
         Some("center") => el = el.items_center(),
         Some("start") | Some("flex-start") => el = el.items_start(),
         Some("end") | Some("flex-end") => el = el.items_end(),
+        _ => {}
+    }
+    match style.align_content.as_deref() {
+        Some("center") => el = el.content_center(),
+        Some("start") | Some("flex-start") => el = el.content_start(),
+        Some("end") | Some("flex-end") => el = el.content_end(),
+        Some("between") | Some("space-between") => el = el.content_between(),
+        Some("around") | Some("space-around") => el = el.content_around(),
+        Some("evenly") | Some("space-evenly") => el = el.content_evenly(),
+        Some("stretch") => el = el.content_stretch(),
+        Some("normal") => el = el.content_normal(),
         _ => {}
     }
     match style.justify_content.as_deref() {
@@ -2790,6 +2804,19 @@ pub(crate) fn apply_styles<E: gpui::Styled>(mut el: E, style: &StyleDesc) -> E {
     }
     if let Some(radius) = style.border_radius {
         el = el.rounded(gpui::px(radius as f32));
+    }
+    // Apply corner longhands after the shorthand so the explicit corner wins.
+    if let Some(radius) = style.border_top_left_radius {
+        el = el.rounded_tl(gpui::px(radius as f32));
+    }
+    if let Some(radius) = style.border_top_right_radius {
+        el = el.rounded_tr(gpui::px(radius as f32));
+    }
+    if let Some(radius) = style.border_bottom_left_radius {
+        el = el.rounded_bl(gpui::px(radius as f32));
+    }
+    if let Some(radius) = style.border_bottom_right_radius {
+        el = el.rounded_br(gpui::px(radius as f32));
     }
     // `borderWidth: 0` must clear a border, not be ignored: an element that
     // draws its own border needs a way for the caller to remove it.

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -2823,9 +2823,33 @@ pub(crate) fn apply_styles<E: gpui::Styled>(mut el: E, style: &StyleDesc) -> E {
     if let Some(width) = style.border_width {
         el = el.border(gpui::px(width.max(0.0) as f32));
     }
+    if let Some(width) = style.border_top_width {
+        el = el.border_t(gpui::px(width.max(0.0) as f32));
+    }
+    if let Some(width) = style.border_right_width {
+        el = el.border_r(gpui::px(width.max(0.0) as f32));
+    }
+    if let Some(width) = style.border_bottom_width {
+        el = el.border_b(gpui::px(width.max(0.0) as f32));
+    }
+    if let Some(width) = style.border_left_width {
+        el = el.border_l(gpui::px(width.max(0.0) as f32));
+    }
     if let Some(ref color) = style.border_color {
         if let Some(hex) = parse_color_hex(color) {
             el = el.border_color(gpui::rgba(hex));
+        }
+    }
+    if let Some(ref shadow) = style.box_shadow {
+        if let Some(hex) = parse_color_hex(&shadow.color) {
+            let shadow = gpui::BoxShadow::new(
+                gpui::px(shadow.offset_x as f32),
+                gpui::px(shadow.offset_y as f32),
+                gpui::rgba(hex).into(),
+            )
+            .blur_radius(gpui::px(shadow.blur_radius.max(0.0) as f32))
+            .spread_radius(gpui::px(shadow.spread_radius as f32));
+            el = el.shadow(vec![shadow]);
         }
     }
     if let Some(opacity) = style.opacity {

--- a/packages/native/src/style.rs
+++ b/packages/native/src/style.rs
@@ -9,6 +9,16 @@ pub enum FontWeightValue {
     Str(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BoxShadowValue {
+    pub offset_x: f64,
+    pub offset_y: f64,
+    pub blur_radius: f64,
+    pub spread_radius: f64,
+    pub color: String,
+}
+
 /// A dimension value that can be a number (pixels) or a string (percentage, auto, etc.)
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
@@ -151,12 +161,17 @@ pub struct StyleDesc {
 
     // Border
     pub border_width: Option<f64>,
+    pub border_top_width: Option<f64>,
+    pub border_right_width: Option<f64>,
+    pub border_bottom_width: Option<f64>,
+    pub border_left_width: Option<f64>,
     pub border_color: Option<String>,
     pub border_radius: Option<f64>,
     pub border_top_left_radius: Option<f64>,
     pub border_top_right_radius: Option<f64>,
     pub border_bottom_left_radius: Option<f64>,
     pub border_bottom_right_radius: Option<f64>,
+    pub box_shadow: Option<BoxShadowValue>,
 
     // Text
     pub font_size: Option<f64>,

--- a/packages/react/src/__tests__/style-coverage.test.tsx
+++ b/packages/react/src/__tests__/style-coverage.test.tsx
@@ -116,6 +116,27 @@ describe("style props reach the renderer", () => {
     )
   })
 
+  it("applies per-side border widths after borderWidth", () => {
+    comparePixels(
+      "border-side-width",
+      <div style={{ display: "flex", padding: 20, backgroundColor: "#101010" }}>
+        <div style={{ width: 300, height: 140, backgroundColor: "#7c86ff" }} />
+      </div>,
+      <div style={{ display: "flex", padding: 20, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 140,
+            backgroundColor: "#7c86ff",
+            borderWidth: 0,
+            borderBottomWidth: 12,
+            borderColor: "#ff5c7a",
+          }}
+        />
+      </div>
+    )
+  })
+
   it("applies per-corner border radii after borderRadius", () => {
     comparePixels(
       "border-corner-radius",
@@ -137,6 +158,39 @@ describe("style props reach the renderer", () => {
             backgroundColor: "#7c86ff",
             borderRadius: 72,
             borderTopLeftRadius: 0,
+          }}
+        />
+      </div>
+    )
+  })
+
+  it("applies a structured boxShadow", () => {
+    comparePixels(
+      "box-shadow",
+      <div style={{ display: "flex", padding: 80, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 140,
+            backgroundColor: "#ffffff",
+            borderRadius: 16,
+          }}
+        />
+      </div>,
+      <div style={{ display: "flex", padding: 80, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 140,
+            backgroundColor: "#ffffff",
+            borderRadius: 16,
+            boxShadow: {
+              offsetX: 24,
+              offsetY: 24,
+              blurRadius: 12,
+              spreadRadius: 6,
+              color: "#ff5c7aff",
+            },
           }}
         />
       </div>

--- a/packages/react/src/__tests__/style-coverage.test.tsx
+++ b/packages/react/src/__tests__/style-coverage.test.tsx
@@ -116,6 +116,33 @@ describe("style props reach the renderer", () => {
     )
   })
 
+  it("applies per-corner border radii after borderRadius", () => {
+    comparePixels(
+      "border-corner-radius",
+      <div style={{ display: "flex", padding: 20, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 180,
+            backgroundColor: "#7c86ff",
+            borderRadius: 72,
+          }}
+        />
+      </div>,
+      <div style={{ display: "flex", padding: 20, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 180,
+            backgroundColor: "#7c86ff",
+            borderRadius: 72,
+            borderTopLeftRadius: 0,
+          }}
+        />
+      </div>
+    )
+  })
+
   it("applies rowGap and columnGap", () => {
     // Both were in StyleDesc and implemented nowhere; only `gap` worked.
     const boxes = [0, 1, 2, 3].map((i) => (
@@ -148,6 +175,62 @@ describe("style props reach the renderer", () => {
         {boxes}
       </div>
     )
+  })
+
+  it("applies flexBasis", () => {
+    const boxes = (withBasis: boolean) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          width: 600,
+          height: 120,
+          padding: 20,
+          backgroundColor: "#101010",
+        }}
+      >
+        <div
+          style={{
+            flexGrow: 1,
+            flexBasis: withBasis ? 80 : undefined,
+            backgroundColor: "#7c86ff",
+          }}
+        />
+        <div
+          style={{
+            flexGrow: 1,
+            flexBasis: withBasis ? 320 : undefined,
+            backgroundColor: "#ff5c7a",
+          }}
+        />
+      </div>
+    )
+
+    comparePixels("flex-basis", boxes(false), boxes(true))
+  })
+
+  it("applies alignContent to wrapped rows", () => {
+    const boxes = [0, 1, 2, 3].map((i) => (
+      <div key={i} style={{ width: 120, height: 60, backgroundColor: "#7c86ff" }} />
+    ))
+    const layout = (alignContent?: string) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          alignContent,
+          width: 300,
+          height: 400,
+          padding: 20,
+          backgroundColor: "#101010",
+        }}
+      >
+        {boxes}
+      </div>
+    )
+
+    comparePixels("align-content", layout(), layout("center"))
   })
 
   it("lays out children with display grid", () => {

--- a/packages/react/src/types/host.ts
+++ b/packages/react/src/types/host.ts
@@ -35,6 +35,14 @@ export interface MotionProps {
   transition?: MotionTransition
 }
 
+export interface BoxShadow {
+  offsetX: number
+  offsetY: number
+  blurRadius: number
+  spreadRadius: number
+  color: string
+}
+
 export interface StyleDesc {
   display?: string
   visibility?: string
@@ -86,12 +94,17 @@ export interface StyleDesc {
   opacity?: number
 
   borderWidth?: number
+  borderTopWidth?: number
+  borderRightWidth?: number
+  borderBottomWidth?: number
+  borderLeftWidth?: number
   borderColor?: string
   borderRadius?: number
   borderTopLeftRadius?: number
   borderTopRightRadius?: number
   borderBottomLeftRadius?: number
   borderBottomRightRadius?: number
+  boxShadow?: BoxShadow
 
   fontSize?: number
   fontFamily?: string


### PR DESCRIPTION
## Summary

- apply the declared per-corner radius, `flexBasis`, and `alignContent` styles
- add per-side border widths and one structured `boxShadow`
- keep the TypeScript and native style surfaces in sync
- document the supported props and add changesets

## Verification

- `cd packages/react && bun run test`
- 18 files passed, 209 tests passed
