### PR TITLE
feat(native): support full color function parsing

### DIFF
--- a/.changeset/add-border-sides-and-shadow.md
+++ b/.changeset/add-border-sides-and-shadow.md
@@ -1,0 +1,6 @@
+---
+"@gpuix/native": minor
+"@gpuix/react": minor
+---
+
+Add per-side border widths and one structured `boxShadow` style with offset, blur, spread, and color values.

--- a/.changeset/apply-declared-layout-styles.md
+++ b/.changeset/apply-declared-layout-styles.md
@@ -1,0 +1,5 @@
+---
+"@gpuix/native": patch
+---
+
+Apply per-corner radii, `flexBasis`, and `alignContent` styles that were already declared in the public React style type.

--- a/.changeset/full-color-functions.md
+++ b/.changeset/full-color-functions.md
@@ -1,0 +1,9 @@
+---
+"@gpuix/native": minor
+"@gpuix/react": minor
+---
+
+Accept the full csscolorparser 0.8.3 string grammar across styles, themes,
+pseudo-states, selection colors, SVG tint, borders, and shadows. This adds
+modern RGB/HSL/HWB, HSV, LAB/LCH, OKLab/OKLCH, named, transparent, alpha,
+`none`, and limited relative-color forms without changing TypeScript types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,7 +477,8 @@ pub struct StyleDesc {
     pub padding: Option<f64>,
     pub margin: Option<f64>,
     
-    // Colors (parsed from "#rrggbb" or "rgb(r,g,b)")
+    // Colors (parsed centrally in src/color.rs with csscolorparser 0.8.3;
+    // parser-version changes require running both absolute and relative matrices)
     pub background_color: Option<String>,
     pub color: Option<String>,
     

--- a/README.md
+++ b/README.md
@@ -1218,7 +1218,7 @@ CSS-like styling via the `style` prop:
 </div>
 ```
 
-**Layout:** `display` (`"flex"` | `"grid"`), `flexDirection`, `flexWrap`, `flexGrow`, `flexShrink`, `alignItems`, `alignSelf`, `justifyContent`, `gap`, `rowGap`, `columnGap`, `gridTemplateColumns`, `gridTemplateRows`, `gridColumnMin`, `gridRowMin`
+**Layout:** `display` (`"flex"` | `"grid"`), `flexDirection`, `flexWrap`, `flexGrow`, `flexShrink`, `flexBasis`, `alignItems`, `alignSelf`, `alignContent`, `justifyContent`, `gap`, `rowGap`, `columnGap`, `gridTemplateColumns`, `gridTemplateRows`, `gridColumnMin`, `gridRowMin`
 
 **Sizing:** `width`, `height`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight` — accepts pixels (number) or percentages (string like `"100%"`)
 
@@ -1226,7 +1226,24 @@ CSS-like styling via the `style` prop:
 
 **Position:** `position` (`"relative"` | `"absolute"`), `top`, `right`, `bottom`, `left`
 
-**Visual:** `backgroundColor`, `color`, `opacity`, `cursor`, `pointerEvents`, `borderRadius`, `borderWidth`, `borderColor`
+**Visual:** `backgroundColor`, `color`, `opacity`, `cursor`, `pointerEvents`, `borderRadius`, `borderTopLeftRadius`, `borderTopRightRadius`, `borderBottomLeftRadius`, `borderBottomRightRadius`, `borderWidth`, `borderTopWidth`, `borderRightWidth`, `borderBottomWidth`, `borderLeftWidth`, `borderColor`, `boxShadow`
+
+`boxShadow` accepts one structured shadow. Its fields are `offsetX`, `offsetY`,
+`blurRadius`, `spreadRadius`, and `color`:
+
+```tsx
+<div
+  style={{
+    boxShadow: {
+      offsetX: 0,
+      offsetY: 4,
+      blurRadius: 12,
+      spreadRadius: 0,
+      color: '#00000033',
+    },
+  }}
+/>
+```
 
 **Overflow:** `overflow`, `overflowX`, `overflowY` — `"hidden"` clips content, `"scroll"` creates a native scrollable container with persistent scroll state
 

--- a/README.md
+++ b/README.md
@@ -1228,6 +1228,52 @@ CSS-like styling via the `style` prop:
 
 **Visual:** `backgroundColor`, `color`, `opacity`, `cursor`, `pointerEvents`, `borderRadius`, `borderTopLeftRadius`, `borderTopRightRadius`, `borderBottomLeftRadius`, `borderBottomRightRadius`, `borderWidth`, `borderTopWidth`, `borderRightWidth`, `borderBottomWidth`, `borderLeftWidth`, `borderColor`, `boxShadow`
 
+### Colors
+
+Every color-bearing style field accepts the same string grammar. GPUIX native
+uses `csscolorparser` 0.8.3 and accepts:
+
+- named colors and `transparent`;
+- 3/4/6/8-digit hex, with or without `#`;
+- `rgb()` / `rgba()`, `hsl()` / `hsla()`, `hwb()` / `hwba()`, and
+  `hsv()` / `hsva()`;
+- `lab()`, `lch()`, `oklab()`, and `oklch()`;
+- `none` components and the parser's limited relative-color `from` / `calc()`
+  forms.
+
+Standard comma and modern space/slash alpha forms work. Values are converted
+to hard-clipped sRGB before GPUI paints them. Invalid strings are ignored for
+that property; they do not reject the full style object.
+
+`hsv()`, `hsva()`, and `hwba()` are parser extensions rather than CSS Color 4
+standard functions. `color()`, platform/dynamic colors, and numeric color
+integers are not accepted.
+
+Theme values can use the same modern grammar:
+
+```tsx
+const theme = {
+  surface: 'oklch(18% 0.02 260)',
+  accent: 'oklch(67.3% 0.182 276.935)',
+  text: 'oklch(96% 0 0)',
+}
+
+<div style={{ backgroundColor: theme.surface, borderColor: theme.accent }}>
+  <text style={{ color: theme.text }}>Hello GPUIX!</text>
+</div>
+```
+
+Limited relative-color forms can derive a new color from a base value:
+
+```tsx
+<div
+  style={{
+    backgroundColor: '#bad455',
+    borderColor: 'oklch(from #bad455 calc(l - 0.15) calc(c * 0.7) h)',
+  }}
+/>
+```
+
 `boxShadow` accepts one structured shadow. Its fields are `offsetX`, `offsetY`,
 `blurRadius`, `spreadRadius`, and `color`:
 

--- a/packages/native/Cargo.lock
+++ b/packages/native/Cargo.lock
@@ -1348,6 +1348,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199f851bd3cb5004c09474252c7f74e7c047441ed0979bf3688a7106a13da952"
+dependencies = [
+ "num-traits",
+ "phf",
+ "serde",
+ "uncased",
+]
+
+[[package]]
 name = "ctor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,6 +2518,7 @@ dependencies = [
  "anyhow",
  "core-graphics 0.24.0",
  "core-text",
+ "csscolorparser",
  "env_logger",
  "futures",
  "gpui",
@@ -4128,6 +4141,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+ "uncased",
 ]
 
 [[package]]
@@ -4137,6 +4151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
+ "uncased",
 ]
 
 [[package]]
@@ -6082,6 +6097,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicase"

--- a/packages/native/Cargo.toml
+++ b/packages/native/Cargo.toml
@@ -14,6 +14,7 @@ napi-derive = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
+csscolorparser = "0.8.3"
 log = "0.4"
 env_logger = "0.11"
 parking_lot = "0.12"

--- a/packages/native/src/color.rs
+++ b/packages/native/src/color.rs
@@ -1,0 +1,151 @@
+/// Parse any color accepted by csscolorparser 0.8.3 into GPUI's sRGB paint type.
+/// Out-of-gamut channels are hard-clipped because GPUI paints sRGB Rgba/Hsla.
+pub(crate) fn parse_color_rgba(value: &str) -> Option<gpui::Rgba> {
+    let parsed = csscolorparser::parse(value).ok()?.clamp();
+    Some(gpui::Rgba {
+        r: parsed.r,
+        g: parsed.g,
+        b: parsed.b,
+        a: parsed.a,
+    })
+}
+
+/// Compatibility helper kept at the gpuix-native crate root.
+pub fn parse_color(value: &str) -> Option<(f32, f32, f32, f32)> {
+    parse_color_rgba(value).map(|color| (color.r, color.g, color.b, color.a))
+}
+
+/// Compatibility helper kept at the gpuix-native crate root.
+pub fn parse_color_hex(value: &str) -> Option<u32> {
+    parse_color_rgba(value).map(u32::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_same(input: &str, expected: &str) {
+        let actual = parse_color(input).unwrap_or_else(|| panic!("did not parse {input}"));
+        let expected = parse_color(expected).unwrap();
+        for (actual, expected) in [actual.0, actual.1, actual.2, actual.3]
+            .into_iter()
+            .zip([expected.0, expected.1, expected.2, expected.3])
+        {
+            assert!((actual - expected).abs() <= 1.0 / 255.0, "{input}");
+        }
+    }
+
+    #[test]
+    fn parses_every_absolute_function_family() {
+        let cases = [
+            ("#f00f", "#ff0000ff"),
+            ("ff0000ff", "#ff0000ff"),
+            ("rebeccapurple", "#663399"),
+            ("transparent", "#00000000"),
+            ("rgb(255 0 0)", "#ff0000"),
+            ("rgba(255, 0, 0, 1)", "#ff0000"),
+            ("hsl(0 100% 50%)", "#ff0000"),
+            ("hsla(0, 100%, 50%, 1)", "#ff0000"),
+            ("hwb(0 0% 0%)", "#ff0000"),
+            ("hwba(0, 0%, 0%, 1)", "#ff0000"),
+            ("hsv(0 100% 100%)", "#ff0000"),
+            ("hsva(0, 100%, 100%, 1)", "#ff0000"),
+            ("lab(100% 0 0)", "#ffffff"),
+            ("lch(100% 0 0)", "#ffffff"),
+            ("oklab(0.62796 0.22486 0.12585)", "#ff0000"),
+            ("oklch(0.62796 0.25768 29.23388)", "#ff0000"),
+            ("rgb(none none none / none)", "#00000000"),
+        ];
+
+        for (input, expected) in cases {
+            assert_same(input, expected);
+        }
+    }
+
+    #[test]
+    fn parses_alpha_in_every_function_family() {
+        let cases = [
+            "rgb(0 0 0 / 50%)",
+            "rgba(0, 0, 0, 0.5)",
+            "hsl(0 0% 0% / 50%)",
+            "hsla(0, 0%, 0%, 0.5)",
+            "hwb(0 0% 100% / 50%)",
+            "hwba(0, 0%, 100%, 0.5)",
+            "hsv(0 0% 0% / 50%)",
+            "hsva(0, 0%, 0%, 0.5)",
+            "lab(0% 0 0 / 50%)",
+            "lch(0% 0 0 / 50%)",
+            "oklab(0 0 0 / 50%)",
+            "oklch(0 0 0 / 50%)",
+        ];
+
+        for input in cases {
+            let (_, _, _, alpha) =
+                parse_color(input).unwrap_or_else(|| panic!("did not parse {input}"));
+            assert!((alpha - 0.5).abs() < f32::EPSILON, "{input}");
+        }
+    }
+
+    #[test]
+    fn parses_every_relative_function_family() {
+        let cases = [
+            ("rgb(from #bad455 b r g / alpha)", "#55bad4"),
+            ("hsl(from #bad455 h s l / alpha)", "#bad455"),
+            ("hwb(from #bad455 h w b / alpha)", "#bad455"),
+            ("hsv(from #bad455 h s v / alpha)", "#bad455"),
+            ("lab(from #bad455 l a b / alpha)", "#bad455"),
+            ("lch(from #bad455 l c h / alpha)", "#bad455"),
+            ("oklab(from #bad455 calc(l * 0.7) a b)", "#708500"),
+            (
+                "oklch(from #bad455 calc(l - 0.15) calc(c * 0.7) h)",
+                "#8fa150",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_same(input, expected);
+        }
+
+        for input in [
+            "lab(from #bad455 l a b / calc(alpha / 2))",
+            "lch(from #bad455 l c h / calc(alpha * 0.5))",
+        ] {
+            let (_, _, _, alpha) = parse_color(input).unwrap();
+            assert!((alpha - 0.5).abs() < f32::EPSILON, "{input}");
+        }
+    }
+
+    #[test]
+    fn rejects_values_outside_the_parser_contract() {
+        for input in [
+            "",
+            "reddish",
+            "#gg0000",
+            "hsl(nope)",
+            "color(display-p3 1 0 0)",
+        ] {
+            assert_eq!(parse_color_hex(input), None, "{input}");
+        }
+    }
+
+    #[test]
+    fn clips_wide_gamut_output_before_gpui() {
+        let color = parse_color_rgba("oklch(90% 0.4 40)").expect("valid OKLCH");
+        for channel in [color.r, color.g, color.b, color.a] {
+            assert!((0.0..=1.0).contains(&channel));
+        }
+    }
+
+    #[test]
+    fn compatibility_helpers_share_the_same_result() {
+        let rgba = parse_color_rgba("oklch(0.62796 0.25768 29.23388 / 50%)").unwrap();
+        assert_eq!(
+            parse_color("oklch(0.62796 0.25768 29.23388 / 50%)"),
+            Some((rgba.r, rgba.g, rgba.b, rgba.a))
+        );
+        assert_eq!(
+            parse_color_hex("oklch(0.62796 0.25768 29.23388 / 50%)"),
+            Some(u32::from(rgba))
+        );
+    }
+}

--- a/packages/native/src/custom_elements/anchored.rs
+++ b/packages/native/src/custom_elements/anchored.rs
@@ -298,10 +298,10 @@ impl CustomElement for AnchoredElement {
         let has_fill = ctx.style.is_some_and(|style| {
             style
                 .background_color
-                .as_ref()
-                .or(style.background.as_ref())
-                .and_then(|color| crate::style::parse_color_hex(color))
-                .is_some_and(|hex| hex & 0xFF > 0)
+                .as_deref()
+                .or(style.background.as_deref())
+                .and_then(crate::color::parse_color_rgba)
+                .is_some_and(|color| color.a > 0.0)
         });
         if !has_fill {
             content = content.bg(gpui::rgb(0x1A1A1A));

--- a/packages/native/src/custom_elements/img.rs
+++ b/packages/native/src/custom_elements/img.rs
@@ -227,8 +227,7 @@ impl CustomElement for SvgElement {
         let tint = ctx
             .style
             .and_then(|style| style.color.as_deref())
-            .and_then(crate::style::parse_color_hex)
-            .map(gpui::rgba)
+            .and_then(crate::color::parse_color_rgba)
             .unwrap_or_else(|| gpui::rgb(0xe2e2e2).into());
         let mut icon = gpui::svg().data(bytes).flex_none().text_color(tint);
         if let Some(style) = ctx.style {

--- a/packages/native/src/lib.rs
+++ b/packages/native/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 
 mod automation;
+mod color;
 mod custom_elements;
 mod diff;
 mod element_tree;

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -2834,9 +2834,33 @@ pub(crate) fn apply_styles<E: gpui::Styled>(mut el: E, style: &StyleDesc) -> E {
     if let Some(width) = style.border_width {
         el = el.border(gpui::px(width.max(0.0) as f32));
     }
+    if let Some(width) = style.border_top_width {
+        el = el.border_t(gpui::px(width.max(0.0) as f32));
+    }
+    if let Some(width) = style.border_right_width {
+        el = el.border_r(gpui::px(width.max(0.0) as f32));
+    }
+    if let Some(width) = style.border_bottom_width {
+        el = el.border_b(gpui::px(width.max(0.0) as f32));
+    }
+    if let Some(width) = style.border_left_width {
+        el = el.border_l(gpui::px(width.max(0.0) as f32));
+    }
     if let Some(ref color) = style.border_color {
         if let Some(hex) = parse_color_hex(color) {
             el = el.border_color(gpui::rgba(hex));
+        }
+    }
+    if let Some(ref shadow) = style.box_shadow {
+        if let Some(hex) = parse_color_hex(&shadow.color) {
+            let shadow = gpui::BoxShadow::new(
+                gpui::px(shadow.offset_x as f32),
+                gpui::px(shadow.offset_y as f32),
+                gpui::rgba(hex).into(),
+            )
+            .blur_radius(gpui::px(shadow.blur_radius.max(0.0) as f32))
+            .spread_radius(gpui::px(shadow.spread_radius as f32));
+            el = el.shadow(vec![shadow]);
         }
     }
     if let Some(opacity) = style.opacity {

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -2623,10 +2623,24 @@ pub(crate) fn apply_styles<E: gpui::Styled>(mut el: E, style: &StyleDesc) -> E {
     if let Some(shrink) = style.flex_shrink {
         el.style().flex_shrink = Some(shrink as f32);
     }
+    if let Some(basis) = style.flex_basis {
+        el = el.flex_basis(gpui::px(basis as f32));
+    }
     match style.align_items.as_deref() {
         Some("center") => el = el.items_center(),
         Some("start") | Some("flex-start") => el = el.items_start(),
         Some("end") | Some("flex-end") => el = el.items_end(),
+        _ => {}
+    }
+    match style.align_content.as_deref() {
+        Some("center") => el = el.content_center(),
+        Some("start") | Some("flex-start") => el = el.content_start(),
+        Some("end") | Some("flex-end") => el = el.content_end(),
+        Some("between") | Some("space-between") => el = el.content_between(),
+        Some("around") | Some("space-around") => el = el.content_around(),
+        Some("evenly") | Some("space-evenly") => el = el.content_evenly(),
+        Some("stretch") => el = el.content_stretch(),
+        Some("normal") => el = el.content_normal(),
         _ => {}
     }
     match style.justify_content.as_deref() {
@@ -2801,6 +2815,19 @@ pub(crate) fn apply_styles<E: gpui::Styled>(mut el: E, style: &StyleDesc) -> E {
     }
     if let Some(radius) = style.border_radius {
         el = el.rounded(gpui::px(radius as f32));
+    }
+    // Apply corner longhands after the shorthand so the explicit corner wins.
+    if let Some(radius) = style.border_top_left_radius {
+        el = el.rounded_tl(gpui::px(radius as f32));
+    }
+    if let Some(radius) = style.border_top_right_radius {
+        el = el.rounded_tr(gpui::px(radius as f32));
+    }
+    if let Some(radius) = style.border_bottom_left_radius {
+        el = el.rounded_bl(gpui::px(radius as f32));
+    }
+    if let Some(radius) = style.border_bottom_right_radius {
+        el = el.rounded_br(gpui::px(radius as f32));
     }
     // `borderWidth: 0` must clear a border, not be ignored: an element that
     // draws its own border needs a way for the caller to remove it.

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -32,7 +32,7 @@ use std::time::Duration;
 use crate::custom_elements::{CustomElementRegistry, CustomRenderContext};
 use crate::element_tree::EventPayload;
 use crate::retained_tree::RetainedTree;
-use crate::style::{parse_color_hex, StyleDesc};
+use crate::style::StyleDesc;
 use crate::text::{selectable_text, selection_frame_reset, selection_key, SharedSelection};
 use crate::theme::Theme;
 
@@ -1535,12 +1535,12 @@ impl Inherited {
             Some("text") | Some("auto") => self.selectable = true,
             _ => {}
         }
-        if let Some(hex) = style
+        if let Some(color) = style
             .selection_color
             .as_deref()
-            .and_then(crate::style::parse_color_hex)
+            .and_then(crate::color::parse_color_rgba)
         {
-            self.selection_wash = gpui::rgba(hex).into();
+            self.selection_wash = color.into();
         }
         self
     }
@@ -2766,13 +2766,13 @@ pub(crate) fn apply_styles<E: gpui::Styled>(mut el: E, style: &StyleDesc) -> E {
         .as_ref()
         .or(style.background.as_ref())
     {
-        if let Some(hex) = parse_color_hex(bg) {
-            el = el.bg(gpui::rgba(hex));
+        if let Some(color) = crate::color::parse_color_rgba(bg) {
+            el = el.bg(color);
         }
     }
     if let Some(ref color) = style.color {
-        if let Some(hex) = parse_color_hex(color) {
-            el = el.text_color(gpui::rgba(hex));
+        if let Some(color) = crate::color::parse_color_rgba(color) {
+            el = el.text_color(color);
         }
     }
     if let Some(size) = style.font_size {
@@ -2847,16 +2847,16 @@ pub(crate) fn apply_styles<E: gpui::Styled>(mut el: E, style: &StyleDesc) -> E {
         el = el.border_l(gpui::px(width.max(0.0) as f32));
     }
     if let Some(ref color) = style.border_color {
-        if let Some(hex) = parse_color_hex(color) {
-            el = el.border_color(gpui::rgba(hex));
+        if let Some(color) = crate::color::parse_color_rgba(color) {
+            el = el.border_color(color);
         }
     }
     if let Some(ref shadow) = style.box_shadow {
-        if let Some(hex) = parse_color_hex(&shadow.color) {
+        if let Some(color) = crate::color::parse_color_rgba(&shadow.color) {
             let shadow = gpui::BoxShadow::new(
                 gpui::px(shadow.offset_x as f32),
                 gpui::px(shadow.offset_y as f32),
-                gpui::rgba(hex).into(),
+                color.into(),
             )
             .blur_radius(gpui::px(shadow.blur_radius.max(0.0) as f32))
             .spread_radius(gpui::px(shadow.spread_radius as f32));

--- a/packages/native/src/style.rs
+++ b/packages/native/src/style.rs
@@ -9,6 +9,16 @@ pub enum FontWeightValue {
     Str(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BoxShadowValue {
+    pub offset_x: f64,
+    pub offset_y: f64,
+    pub blur_radius: f64,
+    pub spread_radius: f64,
+    pub color: String,
+}
+
 /// A dimension value that can be a number (pixels) or a string (percentage, auto, etc.)
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
@@ -151,12 +161,17 @@ pub struct StyleDesc {
 
     // Border
     pub border_width: Option<f64>,
+    pub border_top_width: Option<f64>,
+    pub border_right_width: Option<f64>,
+    pub border_bottom_width: Option<f64>,
+    pub border_left_width: Option<f64>,
     pub border_color: Option<String>,
     pub border_radius: Option<f64>,
     pub border_top_left_radius: Option<f64>,
     pub border_top_right_radius: Option<f64>,
     pub border_bottom_left_radius: Option<f64>,
     pub border_bottom_right_radius: Option<f64>,
+    pub box_shadow: Option<BoxShadowValue>,
 
     // Text
     pub font_size: Option<f64>,

--- a/packages/native/src/style.rs
+++ b/packages/native/src/style.rs
@@ -235,8 +235,31 @@ pub fn should_occlude(style: &StyleDesc) -> bool {
     let Some(color) = fill else {
         return false;
     };
-    match parse_color_hex(color) {
-        Some(hex) => hex & 0xFF > 0,
+    match crate::color::parse_color_rgba(color) {
+        Some(color) => color.a > 0.0,
         None => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_fill(fill: &str) -> StyleDesc {
+        StyleDesc {
+            background_color: Some(fill.to_owned()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn transparent_function_does_not_occlude() {
+        assert!(!should_occlude(&with_fill("transparent")));
+        assert!(!should_occlude(&with_fill("oklch(50% 0.2 30 / 0%)")));
+    }
+
+    #[test]
+    fn invalid_fill_keeps_conservative_occlusion() {
+        assert!(should_occlude(&with_fill("not-a-color")));
     }
 }

--- a/packages/native/src/style.rs
+++ b/packages/native/src/style.rs
@@ -208,77 +208,7 @@ pub struct StyleDesc {
     pub active: Option<Box<StyleDesc>>,
 }
 
-/// Parse a color string (hex, rgb, etc.) to GPUI Hsla
-pub fn parse_color(color: &str) -> Option<(f32, f32, f32, f32)> {
-    let color = color.trim();
-
-    // Handle hex colors
-    if color.starts_with('#') {
-        let hex = &color[1..];
-        match hex.len() {
-            3 => {
-                // #RGB -> #RRGGBB
-                let r = u8::from_str_radix(&hex[0..1].repeat(2), 16).ok()? as f32 / 255.0;
-                let g = u8::from_str_radix(&hex[1..2].repeat(2), 16).ok()? as f32 / 255.0;
-                let b = u8::from_str_radix(&hex[2..3].repeat(2), 16).ok()? as f32 / 255.0;
-                return Some((r, g, b, 1.0));
-            }
-            6 => {
-                let r = u8::from_str_radix(&hex[0..2], 16).ok()? as f32 / 255.0;
-                let g = u8::from_str_radix(&hex[2..4], 16).ok()? as f32 / 255.0;
-                let b = u8::from_str_radix(&hex[4..6], 16).ok()? as f32 / 255.0;
-                return Some((r, g, b, 1.0));
-            }
-            8 => {
-                let r = u8::from_str_radix(&hex[0..2], 16).ok()? as f32 / 255.0;
-                let g = u8::from_str_radix(&hex[2..4], 16).ok()? as f32 / 255.0;
-                let b = u8::from_str_radix(&hex[4..6], 16).ok()? as f32 / 255.0;
-                let a = u8::from_str_radix(&hex[6..8], 16).ok()? as f32 / 255.0;
-                return Some((r, g, b, a));
-            }
-            _ => return None,
-        }
-    }
-
-    // Handle rgb/rgba
-    if color.starts_with("rgb") {
-        let inner = color
-            .trim_start_matches("rgba(")
-            .trim_start_matches("rgb(")
-            .trim_end_matches(')');
-        let parts: Vec<&str> = inner.split(',').map(|s| s.trim()).collect();
-
-        if parts.len() >= 3 {
-            let r = parts[0].parse::<f32>().ok()? / 255.0;
-            let g = parts[1].parse::<f32>().ok()? / 255.0;
-            let b = parts[2].parse::<f32>().ok()? / 255.0;
-            let a = if parts.len() == 4 {
-                parts[3].parse::<f32>().ok()?
-            } else {
-                1.0
-            };
-            return Some((r, g, b, a));
-        }
-    }
-
-    None
-}
-
-/// Convert RGBA floats (0.0-1.0) to a hex u32 for GPUI's rgba() function
-/// Format: 0xRRGGBBAA
-pub fn rgba_to_hex(r: f32, g: f32, b: f32, a: f32) -> u32 {
-    let r = (r.clamp(0.0, 1.0) * 255.0) as u32;
-    let g = (g.clamp(0.0, 1.0) * 255.0) as u32;
-    let b = (b.clamp(0.0, 1.0) * 255.0) as u32;
-    let a = (a.clamp(0.0, 1.0) * 255.0) as u32;
-    (r << 24) | (g << 16) | (b << 8) | a
-}
-
-/// Parse a color string and return a hex u32 for GPUI
-pub fn parse_color_hex(color: &str) -> Option<u32> {
-    let (r, g, b, a) = parse_color(color)?;
-    Some(rgba_to_hex(r, g, b, a))
-}
+pub use crate::color::{parse_color, parse_color_hex};
 
 /// Whether this style should insert a mouse hitbox.
 ///

--- a/packages/native/src/theme.rs
+++ b/packages/native/src/theme.rs
@@ -594,8 +594,8 @@ impl Default for Theme {
 }
 
 fn set(slot: &mut Hsla, value: &Option<String>) {
-    if let Some(hex) = value.as_deref().and_then(crate::style::parse_color_hex) {
-        *slot = gpui::rgba(hex).into();
+    if let Some(color) = value.as_deref().and_then(crate::color::parse_color_rgba) {
+        *slot = color.into();
     }
 }
 
@@ -766,6 +766,27 @@ mod tests {
         assert_eq!(t.syntax.keyword, gpui::rgba(0x00ff00ff).into());
         assert_eq!(t.diff_add, base.diff_add);
         assert_eq!(t.syntax.string, base.syntax.string);
+    }
+
+    #[test]
+    fn override_accepts_full_color_functions() {
+        let base = Theme::dark();
+        let o: ThemeOverride = serde_json::from_str(
+            r#"{
+          "text": "oklch(0.62796 0.25768 29.23388)",
+          "caret": "hsl(240 100% 50%)",
+          "syntax": { "keyword": "rebeccapurple" }
+        }"#,
+        )
+        .unwrap();
+        let t = base.with_override(&o);
+        let text: gpui::Rgba = t.text.into();
+        assert!((text.r - 1.0).abs() < 0.001);
+        assert!(text.g.abs() < 0.001);
+        assert!(text.b.abs() < 0.001);
+        assert!((text.a - 1.0).abs() < f32::EPSILON);
+        assert_eq!(t.caret, gpui::rgba(0x0000ffff).into());
+        assert_eq!(t.syntax.keyword, gpui::rgba(0x663399ff).into());
     }
 
     #[test]

--- a/packages/react/src/__tests__/color-functions.test.tsx
+++ b/packages/react/src/__tests__/color-functions.test.tsx
@@ -1,0 +1,154 @@
+import fs from "fs"
+import path from "path"
+import React from "react"
+import { beforeAll, describe, expect, it } from "vitest"
+import { createTestRoot, hasNativeTestRenderer } from "../testing.js"
+import {
+  expectScreenshotsDiffer,
+  expectScreenshotsEqual,
+  SHOTS_DIR,
+} from "./test-utils.js"
+
+const describeNative = hasNativeTestRenderer ? describe : describe.skip
+
+const absoluteCases = [
+  ["hex4", "#f00f", "#ff0000"],
+  ["hex-no-hash", "ff0000ff", "#ff0000"],
+  ["named", "rebeccapurple", "#663399"],
+  ["rgb", "rgb(255 0 0)", "#ff0000"],
+  ["rgba", "rgba(255, 0, 0, 1)", "#ff0000"],
+  ["hsl", "hsl(0 100% 50%)", "#ff0000"],
+  ["hsla", "hsla(0, 100%, 50%, 1)", "#ff0000"],
+  ["hwb", "hwb(0 0% 0%)", "#ff0000"],
+  ["hwba", "hwba(0, 0%, 0%, 1)", "#ff0000"],
+  ["hsv", "hsv(0 100% 100%)", "#ff0000"],
+  ["hsva", "hsva(0, 100%, 100%, 1)", "#ff0000"],
+  ["lab", "lab(100% 0 0)", "#ffffff"],
+  ["lch", "lch(100% 0 0)", "#ffffff"],
+  ["oklab", "oklab(0 0 0)", "#000000"],
+  ["oklch", "oklch(0 0 0)", "#000000"],
+] as const
+
+const alphaCases = [
+  ["rgb", "rgb(0 0 0 / 50%)"],
+  ["rgba", "rgba(0, 0, 0, 0.5)"],
+  ["hsl", "hsl(0 0% 0% / 50%)"],
+  ["hsla", "hsla(0, 0%, 0%, 0.5)"],
+  ["hwb", "hwb(0 0% 100% / 50%)"],
+  ["hwba", "hwba(0, 0%, 100%, 0.5)"],
+  ["hsv", "hsv(0 0% 0% / 50%)"],
+  ["hsva", "hsva(0, 0%, 0%, 0.5)"],
+  ["lab", "lab(0% 0 0 / 50%)"],
+  ["lch", "lch(0% 0 0 / 50%)"],
+  ["oklab", "oklab(0 0 0 / 50%)"],
+  ["oklch", "oklch(0 0 0 / 50%)"],
+] as const
+
+const relativeCases = [
+  ["rgb", "rgb(from #bad455 b r g / alpha)", "#55bad4"],
+  ["hsl", "hsl(from #bad455 h s l / alpha)", "#bad455"],
+  ["hwb", "hwb(from #bad455 h w b / alpha)", "#bad455"],
+  ["hsv", "hsv(from #bad455 h s v / alpha)", "#bad455"],
+  ["lab", "lab(from #bad455 l a b / alpha)", "#bad455"],
+  ["lch", "lch(from #bad455 l c h / alpha)", "#bad455"],
+  ["oklab", "oklab(from #bad455 calc(l * 0.7) a b)", "#708500"],
+  ["oklch", "oklch(from #bad455 calc(l - 0.15) calc(c * 0.7) h)", "#8fa150"],
+] as const
+
+beforeAll(() => {
+  fs.mkdirSync(SHOTS_DIR, { recursive: true })
+})
+
+function captureColor(name: string, color?: string) {
+  const screenshotPath = path.join(SHOTS_DIR, `${name}.png`)
+  const testRoot = createTestRoot()
+  testRoot.render(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        backgroundColor: color,
+      }}
+    />
+  )
+  testRoot.renderer.captureScreenshot(screenshotPath)
+  return screenshotPath
+}
+
+function expectColorsEqual(name: string, input: string, expected: string) {
+  const actualPath = captureColor(`${name}-actual`, input)
+  const expectedPath = captureColor(`${name}-expected`, expected)
+  expectScreenshotsEqual(actualPath, expectedPath)
+}
+
+describeNative("native color functions", () => {
+  it.each(absoluteCases)(
+    "paints absolute %s exactly like its canonical hex",
+    (name, input, expected) => {
+      expectColorsEqual(`color-absolute-${name}`, input, expected)
+    }
+  )
+
+  it.each(alphaCases)("paints %s alpha exactly like 50% black", (name, input) => {
+    expectColorsEqual(`color-alpha-${name}`, input, "rgba(0 0 0 / 50%)")
+  })
+
+  it.each(relativeCases)(
+    "paints relative %s exactly like its expected hex",
+    (name, input, expected) => {
+      expectColorsEqual(`color-relative-${name}`, input, expected)
+    }
+  )
+
+  it("ignores an invalid paint and paints a valid OKLCH value", () => {
+    const invalidPath = captureColor("color-invalid", "not-a-color")
+    const unsetPath = captureColor("color-unset")
+    expectScreenshotsEqual(invalidPath, unsetPath)
+
+    const validPath = captureColor("color-valid-oklch", "oklch(67.3% 0.182 276.935)")
+    expectScreenshotsDiffer(validPath, unsetPath)
+  })
+
+  it("uses the same parser for compound consumers and pseudo-states", () => {
+    const basePath = path.join(SHOTS_DIR, "color-consumers-base.png")
+    const hoverPath = path.join(SHOTS_DIR, "color-consumers-hover.png")
+    const activePath = path.join(SHOTS_DIR, "color-consumers-active.png")
+    const testRoot = createTestRoot()
+
+    testRoot.render(
+      <div
+        style={{
+          width: 360,
+          height: 180,
+          backgroundColor: "oklch(67.3% 0.182 276.935)",
+          borderWidth: 8,
+          borderColor: "hwb(0 0% 0%)",
+          color: "hsl(0 0% 100%)",
+          selectionColor: "lab(70% 40 30 / 35%)",
+          boxShadow: {
+            offsetX: 18,
+            offsetY: 18,
+            blurRadius: 10,
+            spreadRadius: 4,
+            color: "oklab(45% 0.1 0.05 / 45%)",
+          },
+          hover: { backgroundColor: "hsv(210 80% 70%)" },
+          active: { backgroundColor: "lch(60% 80 40)" },
+        }}
+      >
+        <text>Full color path</text>
+      </div>
+    )
+
+    testRoot.renderer.nativeSimulateMouseMove(500, 500)
+    testRoot.renderer.captureScreenshot(basePath)
+    testRoot.renderer.nativeSimulateMouseMove(180, 90)
+    testRoot.renderer.captureScreenshot(hoverPath)
+    testRoot.renderer.nativeSimulateMouseDown(180, 90)
+    testRoot.renderer.captureScreenshot(activePath)
+
+    expectScreenshotsDiffer(basePath, hoverPath)
+    expectScreenshotsDiffer(hoverPath, activePath)
+    expectScreenshotsDiffer(basePath, activePath)
+  })
+})

--- a/packages/react/src/__tests__/floating-controls.test.tsx
+++ b/packages/react/src/__tests__/floating-controls.test.tsx
@@ -204,6 +204,45 @@ describeNative("floating controls", () => {
     expect(testRoot.renderer.getAllText()).toContain("Behind: 1")
   })
 
+  it("lets a transparent overlapping element pass clicks through", () => {
+    function Demo() {
+      const [behind, setBehind] = useState(0)
+      return (
+        <div
+          style={{ width: 400, height: 260, position: "relative", color: "#ffffff" }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 20,
+              width: 200,
+              height: 80,
+              backgroundColor: "#1e3a5f",
+            }}
+            onClick={() => setBehind((count) => count + 1)}
+          >
+            <text>Behind</text>
+          </div>
+          <div
+            style={{
+              marginTop: 40,
+              marginLeft: 20,
+              width: 200,
+              height: 80,
+              backgroundColor: "transparent",
+            }}
+          />
+          <text>{`Behind: ${behind}`}</text>
+        </div>
+      )
+    }
+
+    testRoot.render(<Demo />)
+    testRoot.renderer.nativeSimulateClick(80, 70)
+    expect(testRoot.renderer.getAllText()).toContain("Behind: 1")
+  })
+
   it("occludes controls behind SelectContent", () => {
     function Demo() {
       const [clicks, setClicks] = useState(0)

--- a/packages/react/src/__tests__/style-coverage.test.tsx
+++ b/packages/react/src/__tests__/style-coverage.test.tsx
@@ -116,6 +116,27 @@ describe("style props reach the renderer", () => {
     )
   })
 
+  it("applies per-side border widths after borderWidth", () => {
+    comparePixels(
+      "border-side-width",
+      <div style={{ display: "flex", padding: 20, backgroundColor: "#101010" }}>
+        <div style={{ width: 300, height: 140, backgroundColor: "#7c86ff" }} />
+      </div>,
+      <div style={{ display: "flex", padding: 20, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 140,
+            backgroundColor: "#7c86ff",
+            borderWidth: 0,
+            borderBottomWidth: 12,
+            borderColor: "#ff5c7a",
+          }}
+        />
+      </div>
+    )
+  })
+
   it("applies per-corner border radii after borderRadius", () => {
     comparePixels(
       "border-corner-radius",
@@ -137,6 +158,39 @@ describe("style props reach the renderer", () => {
             backgroundColor: "#7c86ff",
             borderRadius: 72,
             borderTopLeftRadius: 0,
+          }}
+        />
+      </div>
+    )
+  })
+
+  it("applies a structured boxShadow", () => {
+    comparePixels(
+      "box-shadow",
+      <div style={{ display: "flex", padding: 80, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 140,
+            backgroundColor: "#ffffff",
+            borderRadius: 16,
+          }}
+        />
+      </div>,
+      <div style={{ display: "flex", padding: 80, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 140,
+            backgroundColor: "#ffffff",
+            borderRadius: 16,
+            boxShadow: {
+              offsetX: 24,
+              offsetY: 24,
+              blurRadius: 12,
+              spreadRadius: 6,
+              color: "#ff5c7aff",
+            },
           }}
         />
       </div>

--- a/packages/react/src/__tests__/style-coverage.test.tsx
+++ b/packages/react/src/__tests__/style-coverage.test.tsx
@@ -116,6 +116,33 @@ describe("style props reach the renderer", () => {
     )
   })
 
+  it("applies per-corner border radii after borderRadius", () => {
+    comparePixels(
+      "border-corner-radius",
+      <div style={{ display: "flex", padding: 20, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 180,
+            backgroundColor: "#7c86ff",
+            borderRadius: 72,
+          }}
+        />
+      </div>,
+      <div style={{ display: "flex", padding: 20, backgroundColor: "#101010" }}>
+        <div
+          style={{
+            width: 300,
+            height: 180,
+            backgroundColor: "#7c86ff",
+            borderRadius: 72,
+            borderTopLeftRadius: 0,
+          }}
+        />
+      </div>
+    )
+  })
+
   it("applies rowGap and columnGap", () => {
     // Both were in StyleDesc and implemented nowhere; only `gap` worked.
     const boxes = [0, 1, 2, 3].map((i) => (
@@ -148,6 +175,62 @@ describe("style props reach the renderer", () => {
         {boxes}
       </div>
     )
+  })
+
+  it("applies flexBasis", () => {
+    const boxes = (withBasis: boolean) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          width: 600,
+          height: 120,
+          padding: 20,
+          backgroundColor: "#101010",
+        }}
+      >
+        <div
+          style={{
+            flexGrow: 1,
+            flexBasis: withBasis ? 80 : undefined,
+            backgroundColor: "#7c86ff",
+          }}
+        />
+        <div
+          style={{
+            flexGrow: 1,
+            flexBasis: withBasis ? 320 : undefined,
+            backgroundColor: "#ff5c7a",
+          }}
+        />
+      </div>
+    )
+
+    comparePixels("flex-basis", boxes(false), boxes(true))
+  })
+
+  it("applies alignContent to wrapped rows", () => {
+    const boxes = [0, 1, 2, 3].map((i) => (
+      <div key={i} style={{ width: 120, height: 60, backgroundColor: "#7c86ff" }} />
+    ))
+    const layout = (alignContent?: string) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          alignContent,
+          width: 300,
+          height: 400,
+          padding: 20,
+          backgroundColor: "#101010",
+        }}
+      >
+        {boxes}
+      </div>
+    )
+
+    comparePixels("align-content", layout(), layout("center"))
   })
 
   it("lays out children with display grid", () => {

--- a/packages/react/src/__tests__/test-utils.ts
+++ b/packages/react/src/__tests__/test-utils.ts
@@ -45,3 +45,11 @@ export function expectScreenshotsDiffer(beforePath: string, afterPath: string) {
   const similarity = bufferSimilarity(before, after)
   expect(similarity).toBeLessThan(0.99)
 }
+
+export function expectScreenshotsEqual(leftPath: string, rightPath: string) {
+  expect(fs.existsSync(leftPath)).toBe(true)
+  expect(fs.existsSync(rightPath)).toBe(true)
+  const left = fs.readFileSync(leftPath)
+  const right = fs.readFileSync(rightPath)
+  expect(left.equals(right)).toBe(true)
+}

--- a/packages/react/src/types/host.ts
+++ b/packages/react/src/types/host.ts
@@ -35,6 +35,14 @@ export interface MotionProps {
   transition?: MotionTransition
 }
 
+export interface BoxShadow {
+  offsetX: number
+  offsetY: number
+  blurRadius: number
+  spreadRadius: number
+  color: string
+}
+
 export interface StyleDesc {
   display?: string
   visibility?: string
@@ -86,12 +94,17 @@ export interface StyleDesc {
   opacity?: number
 
   borderWidth?: number
+  borderTopWidth?: number
+  borderRightWidth?: number
+  borderBottomWidth?: number
+  borderLeftWidth?: number
   borderColor?: string
   borderRadius?: number
   borderTopLeftRadius?: number
   borderTopRightRadius?: number
   borderBottomLeftRadius?: number
   borderBottomRightRadius?: number
+  boxShadow?: BoxShadow
 
   fontSize?: number
   fontFamily?: string


### PR DESCRIPTION
## Summary

- parse all csscolorparser 0.8.3 color strings once at the native boundary
- keep the public React style API as strings
- use the same parsed Rgba for styles, themes, pseudo-states, selection, SVG tint, borders, and shadows
- preserve invalid-value fallback behavior while making transparent fills non-occluding

## Ownership

This adds no GPUI patch. The only dependency and adapter live in gpuix-native.

## Proof

- Rust absolute and relative parser matrices
- Rust theme and occlusion tests
- native React renderer screenshot equivalence tests
- native transparent hit-test coverage
- existing style and box-shadow coverage