### PR TITLE
Intern shared styles and skip unchanged updates

### DIFF
--- a/.changeset/skip-unchanged-styles.md
+++ b/.changeset/skip-unchanged-styles.md
@@ -1,0 +1,19 @@
+---
+'@gpuix/react': patch
+'@gpuix/native': patch
+---
+
+Skip unchanged style updates and intern shared style objects.
+
+A later React commit no longer sends `setStyle` when the style object is the same reference, or when a new object has the same fields. Shared style constants are sent once as `internStyle` and then attached with `setStyleId`.
+
+```tsx
+const ROW = { display: 'flex', height: 40 }
+
+// 20 rows share one interned style in Rust
+{items.map((item) => (
+  <div key={item.id} style={ROW}>{item.label}</div>
+))}
+```
+
+This cuts batch size and retained copies for long lists that reuse style objects. Mutating a style object in place without creating a new object is not supported.

--- a/packages/native/index.d.ts
+++ b/packages/native/index.d.ts
@@ -15,6 +15,8 @@ export declare class GpuixRenderer {
   removeChild(parentId: number, childId: number): void
   insertBefore(parentId: number, childId: number, beforeId: number): void
   setStyle(id: number, styleJson: string): void
+  internStyle(styleId: number, styleJson: string): void
+  setStyleId(id: number, styleId: number): void
   setText(id: number, content: string): void
   setEventListener(id: number, eventType: string, hasHandler: boolean): void
   /** Set the root element (called from appendChildToContainer). */
@@ -41,6 +43,8 @@ export declare class GpuixRenderer {
    *   ["removeChild",      parentId, childId]
    *   ["insertBefore",     parentId, childId, beforeId]
    *   ["setStyle",         id, { ...style } | "{styleJson}"]
+   *   ["internStyle",      styleId, { ...style }]
+   *   ["setStyleId",       id, styleId]
    *   ["setText",          id, "content"]
    *   ["setEventListener", id, "eventType", true|false]
    *   ["setRoot",          id]
@@ -125,6 +129,8 @@ export declare class TestGpuixRenderer {
   removeChild(parentId: number, childId: number): void
   insertBefore(parentId: number, childId: number, beforeId: number): void
   setStyle(id: number, styleJson: string): void
+  internStyle(styleId: number, styleJson: string): void
+  setStyleId(id: number, styleId: number): void
   setText(id: number, content: string): void
   setEventListener(id: number, eventType: string, hasHandler: boolean): void
   /** Set the root element (called from appendChildToContainer). */

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -660,6 +660,29 @@ impl GpuixRenderer {
     }
 
     #[napi]
+    pub fn intern_style(&self, style_id: f64, style_json: String) -> Result<()> {
+        let style: StyleDesc = serde_json::from_str(&style_json)
+            .map_err(|e| Error::from_reason(format!("Failed to parse style: {}", e)))?;
+        self.tree
+            .lock()
+            .unwrap()
+            .intern_style(style_id as u32, style)
+            .map_err(Error::from_reason)?;
+        Ok(())
+    }
+
+    #[napi]
+    pub fn set_style_id(&self, id: f64, style_id: f64) -> Result<()> {
+        let id = to_element_id(id)?;
+        self.tree
+            .lock()
+            .unwrap()
+            .set_style_id(id, style_id as u32)
+            .map_err(Error::from_reason)?;
+        Ok(())
+    }
+
+    #[napi]
     pub fn set_text(&self, id: f64, content: String) -> Result<()> {
         let id = to_element_id(id)?;
         let mut tree = self.tree.lock().unwrap();
@@ -724,6 +747,8 @@ impl GpuixRenderer {
     ///   ["removeChild",      parentId, childId]
     ///   ["insertBefore",     parentId, childId, beforeId]
     ///   ["setStyle",         id, { ...style } | "{styleJson}"]
+    ///   ["internStyle",      styleId, { ...style }]
+    ///   ["setStyleId",       id, styleId]
     ///   ["setText",          id, "content"]
     ///   ["setEventListener", id, "eventType", true|false]
     ///   ["setRoot",          id]
@@ -1955,7 +1980,7 @@ pub(crate) fn build_element(
         state.is_valid().then(|| {
             let frame = state.frame(ctx.now);
             *ctx.motion_active |= frame.active;
-            let mut resolved = element.style.clone().unwrap_or_default();
+            let mut resolved = element.style.as_deref().cloned().unwrap_or_default();
             frame.style.apply_to(&mut resolved);
             resolved
         })
@@ -1963,7 +1988,7 @@ pub(crate) fn build_element(
         ctx.motion_states.remove(&id);
         None
     };
-    let style = animated_style.as_ref().or(element.style.as_ref());
+    let style = animated_style.as_ref().or(element.style.as_deref());
 
     // Inheritable style resolves once here so both built-ins and custom
     // elements see the same cascade.
@@ -2907,6 +2932,14 @@ enum BatchOp {
         id: u64,
         style: StyleDesc,
     },
+    InternStyle {
+        style_id: u32,
+        style: StyleDesc,
+    },
+    SetStyleId {
+        id: u64,
+        style_id: u32,
+    },
     SetText {
         id: u64,
         content: String,
@@ -2970,6 +3003,19 @@ fn parse_batch_ops(ops: &[serde_json::Value]) -> Result<Vec<BatchOp>> {
                     style,
                 }
             }
+            "internStyle" => {
+                let style: StyleDesc = batch_decode(arr, 2, i).map_err(|e| {
+                    Error::from_reason(format!("Batch op {} internStyle parse error: {}", i, e))
+                })?;
+                BatchOp::InternStyle {
+                    style_id: batch_id(arr, 1, i)? as u32,
+                    style,
+                }
+            }
+            "setStyleId" => BatchOp::SetStyleId {
+                id: batch_id(arr, 1, i)?,
+                style_id: batch_id(arr, 2, i)? as u32,
+            },
             "setText" => BatchOp::SetText {
                 id: batch_id(arr, 1, i)?,
                 content: batch_str(arr, 2, i)?,
@@ -3018,6 +3064,43 @@ fn parse_batch_ops(ops: &[serde_json::Value]) -> Result<Vec<BatchOp>> {
     Ok(parsed)
 }
 
+fn validate_style_ops(tree: &RetainedTree, ops: &[BatchOp]) -> Result<()> {
+    let mut incoming: HashMap<u32, &StyleDesc> = HashMap::new();
+    let mut available: HashSet<u32> = HashSet::new();
+    for op in ops {
+        match op {
+            BatchOp::InternStyle { style_id, style } => {
+                if let Some(existing) = tree.interned_style(*style_id) {
+                    if existing != style {
+                        return Err(Error::from_reason(format!(
+                            "Interned style id {style_id} already has a different style"
+                        )));
+                    }
+                }
+                if let Some(previous) = incoming.get(style_id) {
+                    if *previous != style {
+                        return Err(Error::from_reason(format!(
+                            "Interned style id {style_id} already has a different style"
+                        )));
+                    }
+                } else {
+                    incoming.insert(*style_id, style);
+                }
+                available.insert(*style_id);
+            }
+            BatchOp::SetStyleId { style_id, .. } => {
+                if !available.contains(style_id) && !tree.has_interned_style(*style_id) {
+                    return Err(Error::from_reason(format!(
+                        "Unknown interned style id {style_id}"
+                    )));
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 /// Apply a batch of mutation tuples to a RetainedTree.
 /// Shared between GpuixRenderer::apply_batch and TestGpuixRenderer::apply_batch.
 /// Returns accumulated destroyed IDs (as f64) from all destroyElement ops.
@@ -3034,6 +3117,7 @@ pub(crate) fn apply_batch_to_tree(
 ) -> Result<Vec<f64>> {
     // Phase 1: parse and validate all ops (no mutation).
     let parsed = parse_batch_ops(ops)?;
+    validate_style_ops(tree, &parsed)?;
 
     // Phase 2: apply all validated ops to the tree.
     let mut destroyed_ids: Vec<f64> = Vec::new();
@@ -3067,6 +3151,14 @@ pub(crate) fn apply_batch_to_tree(
             }
             BatchOp::SetStyle { id, style } => {
                 tree.set_style(id, style);
+            }
+            BatchOp::InternStyle { style_id, style } => {
+                tree.intern_style(style_id, style)
+                    .map_err(Error::from_reason)?;
+            }
+            BatchOp::SetStyleId { id, style_id } => {
+                tree.set_style_id(id, style_id)
+                    .map_err(Error::from_reason)?;
             }
             BatchOp::SetText { id, content } => {
                 tree.set_text(id, content);

--- a/packages/native/src/retained_tree.rs
+++ b/packages/native/src/retained_tree.rs
@@ -7,13 +7,15 @@
 /// All IDs are u64 — JS generates them with an incrementing counter,
 /// passes them as numbers across napi (no string allocation).
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::style::StyleDesc;
 
 pub struct RetainedElement {
     pub id: u64,
     pub element_type: String,
-    pub style: Option<StyleDesc>,
+    pub style: Option<Arc<StyleDesc>>,
+    style_intern_id: Option<u32>,
     pub content: Option<String>,
     pub events: HashSet<String>,
     pub children: Vec<u64>,
@@ -36,6 +38,7 @@ impl RetainedElement {
             id,
             element_type,
             style: None,
+            style_intern_id: None,
             content: None,
             events: HashSet::new(),
             children: Vec::new(),
@@ -50,6 +53,7 @@ impl RetainedElement {
 
 pub struct RetainedTree {
     pub elements: HashMap<u64, RetainedElement>,
+    interned_styles: HashMap<u32, Arc<StyleDesc>>,
     /// The root element ID set by appendChildToContainer.
     pub root_id: Option<u64>,
     next_revision: u64,
@@ -59,6 +63,7 @@ impl RetainedTree {
     pub fn new() -> Self {
         Self {
             elements: HashMap::new(),
+            interned_styles: HashMap::new(),
             root_id: None,
             next_revision: 1,
         }
@@ -106,6 +111,55 @@ impl RetainedTree {
                 self.destroy_element_recursive(child_id, destroyed);
             }
         }
+    }
+
+    pub fn intern_style(&mut self, style_id: u32, style: StyleDesc) -> Result<(), String> {
+        if let Some(existing) = self.interned_styles.get(&style_id) {
+            if existing.as_ref() != &style {
+                return Err(format!(
+                    "Interned style id {style_id} already has a different style"
+                ));
+            }
+            return Ok(());
+        }
+        self.interned_styles.insert(style_id, Arc::new(style));
+        Ok(())
+    }
+
+    pub fn has_interned_style(&self, style_id: u32) -> bool {
+        self.interned_styles.contains_key(&style_id)
+    }
+
+    pub fn interned_style(&self, style_id: u32) -> Option<&StyleDesc> {
+        self.interned_styles.get(&style_id).map(|style| style.as_ref())
+    }
+
+    pub fn set_style_id(&mut self, id: u64, style_id: u32) -> Result<(), String> {
+        let Some(style) = self.interned_styles.get(&style_id).cloned() else {
+            return Err(format!("Unknown interned style id {style_id}"));
+        };
+        let previous = self
+            .elements
+            .get(&id)
+            .and_then(|element| element.style_intern_id);
+        if previous == Some(style_id) {
+            return Ok(());
+        }
+        let Some(element) = self.elements.get_mut(&id) else {
+            return Ok(());
+        };
+        let visual_changed = element.style.as_deref() != Some(style.as_ref());
+        element.style = Some(style);
+        element.style_intern_id = Some(style_id);
+        if visual_changed {
+            self.mark_changed(id);
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn interned_style_count(&self) -> usize {
+        self.interned_styles.len()
     }
 
     pub fn append_child(&mut self, parent_id: u64, child_id: u64) {
@@ -170,10 +224,11 @@ impl RetainedTree {
     pub fn set_style(&mut self, id: u64, style: StyleDesc) {
         let mut changed = false;
         if let Some(element) = self.elements.get_mut(&id) {
-            if element.style.as_ref() != Some(&style) {
-                element.style = Some(style);
+            if element.style.as_deref() != Some(&style) {
+                element.style = Some(Arc::new(style));
                 changed = true;
             }
+            element.style_intern_id = None;
         }
         if changed {
             self.mark_changed(id);
@@ -351,4 +406,97 @@ fn element_to_json(
     }
 
     serde_json::Value::Object(obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    fn sample_style() -> StyleDesc {
+        StyleDesc {
+            display: Some("flex".into()),
+            height: Some(crate::style::DimensionValue::Pixels(40.0)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn style_desc_size_is_tracked() {
+        assert_eq!(
+            size_of::<StyleDesc>(),
+            1272,
+            "StyleDesc grew. Prefer a sparse style over new Option fields."
+        );
+    }
+
+    #[test]
+    fn shared_style_ids_share_one_intern_entry() {
+        let mut tree = RetainedTree::new();
+        tree.create_element(1, "div".into());
+        tree.create_element(2, "div".into());
+        tree.intern_style(1, sample_style()).unwrap();
+        tree.set_style_id(1, 1).unwrap();
+        tree.set_style_id(2, 1).unwrap();
+        assert_eq!(tree.interned_style_count(), 1);
+        assert!(Arc::ptr_eq(
+            tree.elements.get(&1).unwrap().style.as_ref().unwrap(),
+            tree.elements.get(&2).unwrap().style.as_ref().unwrap(),
+        ));
+    }
+
+    #[test]
+    fn destroying_last_user_keeps_interned_style() {
+        let mut tree = RetainedTree::new();
+        tree.create_element(1, "div".into());
+        tree.create_element(2, "div".into());
+        tree.intern_style(1, sample_style()).unwrap();
+        tree.set_style_id(1, 1).unwrap();
+        tree.set_style_id(2, 1).unwrap();
+        tree.destroy_element(1);
+        tree.destroy_element(2);
+        assert_eq!(tree.interned_style_count(), 1);
+        tree.create_element(3, "div".into());
+        tree.set_style_id(3, 1).unwrap();
+        assert!(Arc::ptr_eq(
+            tree.elements.get(&3).unwrap().style.as_ref().unwrap(),
+            tree.interned_styles.get(&1).unwrap(),
+        ));
+    }
+
+    #[test]
+    fn intern_style_rejects_conflicting_reuse() {
+        let mut tree = RetainedTree::new();
+        tree.intern_style(1, sample_style()).unwrap();
+        let mut other = sample_style();
+        other.display = Some("block".into());
+        assert!(tree.intern_style(1, other).is_err());
+    }
+
+    #[test]
+    fn hide_then_restore_keeps_interned_style() {
+        let mut tree = RetainedTree::new();
+        tree.create_element(1, "div".into());
+        tree.intern_style(1, sample_style()).unwrap();
+        tree.set_style_id(1, 1).unwrap();
+        tree.set_style(
+            1,
+            StyleDesc {
+                visibility: Some("hidden".into()),
+                ..Default::default()
+            },
+        );
+        tree.set_style_id(1, 1).unwrap();
+        assert_eq!(
+            tree.elements.get(&1).unwrap().style.as_deref().unwrap().display.as_deref(),
+            Some("flex")
+        );
+    }
+
+    #[test]
+    fn set_style_id_rejects_unknown_intern_id() {
+        let mut tree = RetainedTree::new();
+        tree.create_element(1, "div".into());
+        assert!(tree.set_style_id(1, 99).is_err());
+    }
 }

--- a/packages/native/src/test_renderer.rs
+++ b/packages/native/src/test_renderer.rs
@@ -214,6 +214,29 @@ impl TestGpuixRenderer {
     }
 
     #[napi]
+    pub fn intern_style(&self, style_id: f64, style_json: String) -> Result<()> {
+        let style: StyleDesc = serde_json::from_str(&style_json)
+            .map_err(|e| Error::from_reason(format!("Failed to parse style: {}", e)))?;
+        self.tree
+            .lock()
+            .unwrap()
+            .intern_style(style_id as u32, style)
+            .map_err(Error::from_reason)?;
+        Ok(())
+    }
+
+    #[napi]
+    pub fn set_style_id(&self, id: f64, style_id: f64) -> Result<()> {
+        let id = to_element_id(id)?;
+        self.tree
+            .lock()
+            .unwrap()
+            .set_style_id(id, style_id as u32)
+            .map_err(Error::from_reason)?;
+        Ok(())
+    }
+
+    #[napi]
     pub fn set_text(&self, id: f64, content: String) -> Result<()> {
         let id = to_element_id(id)?;
         self.tree.lock().unwrap().set_text(id, content);

--- a/packages/react/src/__tests__/style-updates.test.tsx
+++ b/packages/react/src/__tests__/style-updates.test.tsx
@@ -1,0 +1,146 @@
+/// Style update batching: skip setStyle when the style did not change.
+
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { createTestRoot } from "../testing.js"
+import type { StyleDesc } from "../types/host.js"
+
+const SHARED: StyleDesc = {
+  display: "flex",
+  height: 40,
+  flexShrink: 0,
+  alignItems: "center",
+}
+
+function styleOps(batch: Array<Array<unknown>>) {
+  return batch.filter((op) => op[0] === "setStyle")
+}
+
+function internOps(batch: Array<Array<unknown>>) {
+  return batch.filter((op) => op[0] === "internStyle")
+}
+
+function styleIdOps(batch: Array<Array<unknown>>) {
+  return batch.filter((op) => op[0] === "setStyleId")
+}
+
+describe("style updates", () => {
+  it("does not resend a shared style object on a later commit", () => {
+    const { render, renderer } = createTestRoot()
+    const tree = (label: string) => (
+      <div style={SHARED}>
+        <text>{label}</text>
+      </div>
+    )
+
+    render(tree("one"))
+    expect(internOps(renderer.lastBatchOps)).toHaveLength(1)
+    expect(styleIdOps(renderer.lastBatchOps).length).toBeGreaterThan(0)
+
+    render(tree("two"))
+    expect(styleOps(renderer.lastBatchOps)).toEqual([])
+    expect(renderer.findByType("div")[0]?.style).toMatchObject(SHARED)
+  })
+
+  it("does not resend a new style object with the same fields", () => {
+    const { render, renderer } = createTestRoot()
+    const tree = (label: string) => (
+      <div style={{ display: "flex", height: 40, color: "#cdd6f4" }}>
+        <text>{label}</text>
+      </div>
+    )
+
+    render(tree("one"))
+    render(tree("two"))
+    expect(styleOps(renderer.lastBatchOps)).toEqual([])
+    expect(internOps(renderer.lastBatchOps)).toEqual([])
+    expect(styleIdOps(renderer.lastBatchOps)).toEqual([])
+  })
+
+  it("interns a new style when a field changes", () => {
+    const { render, renderer } = createTestRoot()
+    const tree = (color: string) => (
+      <div style={{ display: "flex", color }}>
+        <text>x</text>
+      </div>
+    )
+
+    render(tree("#cdd6f4"))
+    render(tree("#f38ba8"))
+    expect(internOps(renderer.lastBatchOps)[0]?.[2]).toMatchObject({ color: "#f38ba8" })
+    expect(styleIdOps(renderer.lastBatchOps)).toHaveLength(1)
+    expect(renderer.findByType("div")[0]?.style.color).toBe("#f38ba8")
+  })
+
+  it("interns a new style when a nested hover style changes", () => {
+    const { render, renderer } = createTestRoot()
+    const tree = (hoverColor: string) => (
+      <div style={{ backgroundColor: "#1e1e2e", hover: { backgroundColor: hoverColor } }}>
+        <text>x</text>
+      </div>
+    )
+
+    render(tree("#313244"))
+    render(tree("#45475a"))
+    expect(internOps(renderer.lastBatchOps)[0]?.[2]).toMatchObject({
+      hover: { backgroundColor: "#45475a" },
+    })
+    expect(styleIdOps(renderer.lastBatchOps)).toHaveLength(1)
+  })
+
+  it("clears style when the style prop is removed", () => {
+    const { render, renderer } = createTestRoot()
+    render(
+      <div style={{ color: "#cdd6f4" }}>
+        <text>x</text>
+      </div>,
+    )
+    render(
+      <div>
+        <text>x</text>
+      </div>,
+    )
+    const ops = styleOps(renderer.lastBatchOps)
+    expect(ops).toHaveLength(1)
+    expect(ops[0]?.[2]).toEqual({})
+  })
+
+  it("interns one shared style for many nodes", () => {
+    const { render, renderer } = createTestRoot()
+    render(
+      <div>
+        {Array.from({ length: 20 }, (_, index) => (
+          <div key={index} style={SHARED}>
+            <text>{`row-${index}`}</text>
+          </div>
+        ))}
+      </div>,
+    )
+    expect(internOps(renderer.lastBatchOps)).toHaveLength(1)
+    expect(styleIdOps(renderer.lastBatchOps)).toHaveLength(20)
+    expect(
+      styleOps(renderer.lastBatchOps).filter((op) => {
+        const style = op[2]
+        return typeof style === "object" && style != null && "height" in style
+      }),
+    ).toEqual([])
+    expect(renderer.findByType("div").filter((node) => node.style.height === 40)).toHaveLength(20)
+  })
+
+  it("reuses a shared style after every user is removed", () => {
+    const { render, renderer } = createTestRoot()
+    const rows = (
+      <div>
+        <div style={SHARED}>
+          <text>row</text>
+        </div>
+      </div>
+    )
+    render(rows)
+    render(<div />)
+    render(rows)
+    expect(internOps(renderer.lastBatchOps)).toEqual([])
+    expect(styleIdOps(renderer.lastBatchOps).length).toBeGreaterThan(0)
+    expect(renderer.findByType("div").some((node) => node.style.height === 40)).toBe(true)
+  })
+})

--- a/packages/react/src/reconciler/batch-renderer.ts
+++ b/packages/react/src/reconciler/batch-renderer.ts
@@ -51,6 +51,8 @@ const BATCHED_METHODS = new Set([
   "removeChild",
   "insertBefore",
   "setStyle",
+  "internStyle",
+  "setStyleId",
   "setText",
   "setEventListener",
   "setRoot",
@@ -73,6 +75,14 @@ export function wrapWithBatching(inner: NativeRenderer): NativeRenderer {
         if (prop === "setStyle") {
           return (id: number, style: string | object) => {
             target.setStyle(id, typeof style === "string" ? style : JSON.stringify(style))
+          }
+        }
+        if (prop === "internStyle") {
+          return (styleId: number, style: string | object) => {
+            target.internStyle(
+              styleId,
+              typeof style === "string" ? style : JSON.stringify(style),
+            )
           }
         }
         if (prop === "setCustomProp") {

--- a/packages/react/src/reconciler/host-config.ts
+++ b/packages/react/src/reconciler/host-config.ts
@@ -17,6 +17,7 @@ import type {
   NativeRenderer,
   Props,
   PublicInstance,
+  StyleDesc,
   TextInstance,
 } from "../types/host.js"
 import {
@@ -27,11 +28,21 @@ import {
 
 let elementIdCounter = 0
 let currentUpdatePriority = NoEventPriority
+let styleIntern = new WeakMap<object, number>()
+let nextStyleInternId = 1
 
 // Renderer reference — set by createRoot before any reconciler work.
 let nativeRenderer: NativeRenderer | null = null
 
+function resetStyleIntern(): void {
+  styleIntern = new WeakMap()
+  nextStyleInternId = 1
+}
+
 export function setNativeRenderer(renderer: NativeRenderer): void {
+  if (nativeRenderer !== renderer) {
+    resetStyleIntern()
+  }
   nativeRenderer = renderer
 }
 
@@ -111,10 +122,50 @@ function diffEventListeners(id: number, oldProps: Props, newProps: Props): void 
 
 // ── Style helper ─────────────────────────────────────────────────────
 
+function stylesEqual(left?: StyleDesc, right?: StyleDesc): boolean {
+  if (left === right) return true
+  if (left == null || right == null) return false
+  const leftEntries = Object.entries(left)
+  const rightEntries = Object.entries(right)
+  if (leftEntries.length !== rightEntries.length) return false
+  const rightValues = new Map(rightEntries)
+  for (const [key, leftValue] of leftEntries) {
+    if (!rightValues.has(key)) return false
+    if (key === "hover") {
+      if (!stylesEqual(left.hover, right.hover)) return false
+      continue
+    }
+    if (key === "active") {
+      if (!stylesEqual(left.active, right.active)) return false
+      continue
+    }
+    if (leftValue !== rightValues.get(key)) return false
+  }
+  return true
+}
+
+function internStyle(style: StyleDesc): number {
+  const existing = styleIntern.get(style)
+  if (existing != null) return existing
+  const styleId = nextStyleInternId++
+  styleIntern.set(style, styleId)
+  getRenderer().internStyle(styleId, style)
+  return styleId
+}
+
+function applyStyle(id: number, style: StyleDesc | undefined): void {
+  const r = getRenderer()
+  if (style == null || Object.keys(style).length === 0) {
+    r.setStyle(id, {})
+    return
+  }
+  r.setStyleId(id, internStyle(style))
+}
+
 function sendStyle(id: number, props: Props): void {
   const style = props.style
   if (style == null || Object.keys(style).length === 0) return
-  getRenderer().setStyle(id, style)
+  applyStyle(id, style)
 }
 
 // ── Custom prop forwarding ───────────────────────────────────────────
@@ -209,7 +260,7 @@ export const hostConfig = {
     sendStyle(id, props)
     syncEventListeners(id, props)
     syncCustomProps(id, type, props)
-    return { id, type, props }
+    return { id, type }
   },
 
   appendChild(parent: Instance, child: Instance | TextInstance): void {
@@ -313,14 +364,11 @@ export const hostConfig = {
     newProps: Props,
     _internalInstanceHandle: unknown
   ): void {
-    // Always resend style — per-element JSON is small, and this avoids
-    // bugs from same-reference mutations or style removal.
-    getRenderer().setStyle(instance.id, newProps.style ?? {})
-    // Event diff
+    if (!stylesEqual(oldProps.style, newProps.style)) {
+      applyStyle(instance.id, newProps.style)
+    }
     diffEventListeners(instance.id, oldProps, newProps)
-    // Custom prop diff (for non-div/text elements)
     diffCustomProps(instance.id, instance.type, oldProps, newProps)
-    instance.props = newProps
   },
 
   commitTextUpdate(
@@ -344,8 +392,8 @@ export const hostConfig = {
     getRenderer().setStyle(instance.id, { visibility: "hidden" })
   },
 
-  unhideInstance(instance: Instance, _props: Props): void {
-    getRenderer().setStyle(instance.id, instance.props.style ?? {})
+  unhideInstance(instance: Instance, props: Props): void {
+    applyStyle(instance.id, props.style)
   },
 
   hideTextInstance(_textInstance: TextInstance): void {},

--- a/packages/react/src/testing.ts
+++ b/packages/react/src/testing.ts
@@ -103,6 +103,8 @@ export interface TestElement {
 
 export class TestRenderer implements NativeRenderer {
   commitCount = 0
+  /** Last applyBatch payload. Empty when a commit sent no mutations. */
+  lastBatchOps: Array<Array<number | string | boolean | object | null>> = []
 
   /** Native TestGpuixRenderer — all state lives here in Rust's RetainedTree. */
   private native: NativeTestRendererApi
@@ -142,6 +144,17 @@ export class TestRenderer implements NativeRenderer {
     this.native.setStyle(id, styleJson)
   }
 
+  internStyle(styleId: number, style: string | object): void {
+    this.native.internStyle(
+      styleId,
+      typeof style === "string" ? style : JSON.stringify(style),
+    )
+  }
+
+  setStyleId(id: number, styleId: number): void {
+    this.native.setStyleId(id, styleId)
+  }
+
   setText(id: number, content: string): void {
     this.native.setText(id, content)
   }
@@ -159,11 +172,13 @@ export class TestRenderer implements NativeRenderer {
   }
 
   commitMutations(): void {
+    this.lastBatchOps = []
     this.native.commitMutations()
     this.commitCount++
   }
 
   applyBatch(json: string): Array<number> {
+    this.lastBatchOps = JSON.parse(json)
     return this.native.applyBatch(json)
   }
 

--- a/packages/react/src/types/host.ts
+++ b/packages/react/src/types/host.ts
@@ -405,6 +405,8 @@ export interface NativeRenderer {
   removeChild(parentId: number, childId: number): void
   insertBefore(parentId: number, childId: number, beforeId: number): void
   setStyle(id: number, styleJson: string | object): void
+  internStyle(styleId: number, style: string | object): void
+  setStyleId(id: number, styleId: number): void
   setText(id: number, content: string): void
   setEventListener(id: number, eventType: string, hasHandler: boolean): void
   setRoot(id: number): void
@@ -454,7 +456,6 @@ export interface Container {
 export interface Instance {
   id: number
   type: ElementType
-  props: Props
 }
 
 // Text instance for raw text nodes


### PR DESCRIPTION
Took the intern/skip-style work off main so it can land after a real profile.

**What this does**
- Shared JS style objects go to Rust once (`internStyle`) and attach with `setStyleId`
- Nodes store `Arc<StyleDesc>` instead of a cloned 1272-byte struct
- Later commits skip `setStyle` when the object or fields did not change
- Intern ids live for the renderer life. A bad `setStyleId` fails before any batch mutation

**Why it is a PR**
No profile yet. Skip-unchanged should cut chrome-update FFI. Intern should cut first-batch parse and retained copies when many nodes share one object. Chat already windows rows, so intern is not a 10k-row RAM win there.

**Check**
- `packages/react` style-updates + styles + events + virtual-list
- `examples/chat.test.tsx` 9/9
- Live `launch()` of `chat.tsx`, sidebar open/collapse screenshots

Do not mutate a style object in place. Pass a new object.