### PR TITLE
fix: make example CI deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,13 @@ The overlay shows **draw time**, not FPS. `8.3 MS` is about 120 Hz.
 
 The chat example has a regression test for this: `examples/chat.perf.test.tsx`. It times mount, wheel draw, and sidebar clicks. It asserts p95, not every frame.
 
+The default example suite excludes this hardware-timing test so shared CI runner variance does not fail functional checks. Run it explicitly on the target Mac:
+
 On macOS, `THROTTLE=utility` restarts the process under `taskpolicy -c utility`. That pins work to E-cores. It is an **M1/M2 Air CPU** proxy, not Chrome 6x. GPU and RAM stay fast. `THROTTLE=background` is slower.
 
 ```bash
 cd examples
-THROTTLE=utility bun run test chat.perf.test.tsx
+THROTTLE=utility bun run test:perf
 THROTTLE=utility bun --hot chat.tsx
 ```
 

--- a/examples/chat.test.tsx
+++ b/examples/chat.test.tsx
@@ -164,20 +164,24 @@ describeNative('chat example', () => {
     expect(selected).not.toContain('Native SDK vs GPUI comparison')
   })
 
-  it('opens the model picker and changes the selected model', () => {
+  it('opens the model picker and changes the selected model', async () => {
     const { render, renderer } = createTestRoot()
     render(<ChatApp />)
 
     expect(renderer.getPaintedText()).toContain('DeepSeek V4 Flash')
     expect(renderer.getPaintedText()).not.toContain('Claude Opus 4.6')
 
-    renderer.nativeSimulateClick(480, 724)
-    renderer.flush()
-    expect(renderer.getPaintedText()).toContain('Claude Opus 4.6')
+    const app = await connectTest(renderer)
+    try {
+      await app.getByTestId('model-picker').click()
+      expect(renderer.getPaintedText()).toContain('Claude Opus 4.6')
 
-    const shot = path.join(SHOTS, 'chat-model-picker.png')
-    renderer.captureScreenshot(shot)
-    expect(fs.statSync(shot).size).toBeGreaterThan(0)
+      const shot = path.join(SHOTS, 'chat-model-picker.png')
+      renderer.captureScreenshot(shot)
+      expect(fs.statSync(shot).size).toBeGreaterThan(0)
+    } finally {
+      await app.close()
+    }
   })
 
   it('types into the composer and clears on enter', () => {

--- a/examples/chat.tsx
+++ b/examples/chat.tsx
@@ -907,6 +907,7 @@ function ChipSelect({
   caret = true,
   accent,
   menuWidth,
+  testId,
   children,
 }: {
   value: string
@@ -916,12 +917,14 @@ function ChipSelect({
   caret?: boolean
   accent?: boolean
   menuWidth?: number
+  testId?: string
   children: React.ReactNode
 }) {
   return (
     <Select value={value} onValueChange={onChange} style={{ flexShrink: 0 }}>
       <div style={{ position: 'relative', display: 'flex' }}>
         <SelectTrigger
+          testId={testId}
           style={(state) => ({
             display: 'flex',
             flexDirection: 'row',
@@ -971,7 +974,13 @@ function ModelPicker({ value, onChange }: { value: string; onChange: (next: stri
   }, [])
 
   return (
-    <ChipSelect value={value} onChange={onChange} icon={selected.icon} label={selected.label}>
+    <ChipSelect
+      value={value}
+      onChange={onChange}
+      icon={selected.icon}
+      label={selected.label}
+      testId="model-picker"
+    >
       {groups.map((group, index) => (
         <div key={group.name} style={{ display: 'flex', flexDirection: 'column' }}>
           {index > 0 && (

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "counter": "bun --hot counter.tsx",
     "diff": "bun --hot diff.tsx",
-    "test": "vitest run",
+    "test": "vitest run --exclude '**/*.perf.test.tsx'",
+    "test:perf": "vitest run chat.perf.test.tsx",
     "native-text": "bun --hot native-text.tsx",
     "chat": "bun --hot chat.tsx",
     "compile": "bun compile-chat.ts"


### PR DESCRIPTION
The expanded example suite exposed two unrelated sources of CI instability:

- the model-picker test clicked a hard-coded screen coordinate, so layout changes could miss a working trigger;
- the chat performance benchmark enforced hardware timing budgets on a shared macOS runner.

This gives the model trigger a stable `testId` and uses the existing automation locator. It also keeps hardware timing in an explicit `bun run test:perf` command while the default example suite runs deterministic functional tests.

Observed failures addressed:
- main run 32713676256: model picker assertion;
- PR run 32714503221: wheel p95 varied to 12.54ms against an 8ms local-hardware budget, while all 15 functional example tests passed.