### PR TITLE
Keep remount ids unique on one native renderer

### DIFF
--- a/.changeset/isolate-root-ids.md
+++ b/.changeset/isolate-root-ids.md
@@ -2,9 +2,9 @@
 "@gpuix/react": patch
 ---
 
-Give each React root its own element ids and event handler map.
+Give each React root its own event handler map. Two `createTestRoot()` trees can both start at id `1` without overwriting each other's handlers. `resetIdCounter()` is gone.
 
-Two `createTestRoot()` trees can both start at id `1`. A click on one root no longer overwrites the other root's handlers. `resetIdCounter()` is gone.
+A remount on the same native renderer keeps allocating new ids. A late event from the old tree cannot hit a new handler that reused id `1`.
 
 `handleGpuixEvent` now needs the renderer that produced the event:
 

--- a/packages/react/src/__tests__/mutation-lifecycle.test.tsx
+++ b/packages/react/src/__tests__/mutation-lifecycle.test.tsx
@@ -1,7 +1,8 @@
 import { Suspense } from "react"
 import { describe, expect, it, vi } from "vitest"
 import { handleGpuixEvent } from "../reconciler/event-registry.js"
-import { createTestRoot, hasNativeTestRenderer } from "../testing.js"
+import { createRoot, flushSync } from "../reconciler/reconciler.js"
+import { createTestRoot, hasNativeTestRenderer, TestRenderer } from "../testing.js"
 
 const describeNative = hasNativeTestRenderer ? describe : describe.skip
 
@@ -85,6 +86,36 @@ describeNative("mutation lifecycle", () => {
     } finally {
       a.unmount()
       b.unmount()
+    }
+  })
+
+  it("does not give a remounted root the old element ids", () => {
+    const renderer = new TestRenderer()
+    const first = createRoot(renderer)
+    const onFirst = vi.fn()
+    const onSecond = vi.fn()
+    const tree = (onClick: () => void) => (
+      <div style={{ width: 100, height: 100 }} onClick={onClick}>
+        row
+      </div>
+    )
+
+    flushSync(() => first.render(tree(onFirst)))
+    renderer.flush()
+    const firstRootId = renderer.getRoot()?.id
+    expect(firstRootId).toBe(2)
+    first.unmount()
+
+    const second = createRoot(renderer)
+    try {
+      flushSync(() => second.render(tree(onSecond)))
+      renderer.flush()
+      expect(renderer.getRoot()?.id).not.toBe(firstRootId)
+
+      handleGpuixEvent({ elementId: firstRootId!, eventType: "click" }, renderer)
+      expect(onSecond).not.toHaveBeenCalled()
+    } finally {
+      second.unmount()
     }
   })
 })

--- a/packages/react/src/reconciler/host-config.ts
+++ b/packages/react/src/reconciler/host-config.ts
@@ -54,7 +54,7 @@ function rendererFor(node: HostNode): NativeRenderer {
 }
 
 function nextId(container: Container): number {
-  return ++container.nextElementId
+  return ++container.ids.nextElementId
 }
 
 // ── Event wiring helpers ─────────────────────────────────────────────

--- a/packages/react/src/reconciler/reconciler.ts
+++ b/packages/react/src/reconciler/reconciler.ts
@@ -4,7 +4,7 @@ import ReactReconciler from "react-reconciler"
 import type { OpaqueRoot } from "react-reconciler"
 import { ConcurrentRoot } from "react-reconciler/constants.js"
 import { GpuixContext } from "../hooks/use-gpuix.js"
-import type { Container, NativeRenderer } from "../types/host.js"
+import type { Container, ElementIdAllocator, NativeRenderer } from "../types/host.js"
 import { wrapWithBatching } from "./batch-renderer.js"
 import { attachRoot, detachRoot } from "./event-registry.js"
 import { hostConfig } from "./host-config.js"
@@ -31,12 +31,23 @@ export interface Root {
   unmount: () => void
 }
 
+const idAllocators = new WeakMap<NativeRenderer, ElementIdAllocator>()
+
+function idAllocatorFor(renderer: NativeRenderer): ElementIdAllocator {
+  let alloc = idAllocators.get(renderer)
+  if (!alloc) {
+    alloc = { nextElementId: 0 }
+    idAllocators.set(renderer, alloc)
+  }
+  return alloc
+}
+
 export function createRoot(renderer: NativeRenderer): Root {
   let container: OpaqueRoot | null = null
   const batchedRenderer = wrapWithBatching(renderer)
   const gpuixContainer: Container = {
     renderer: batchedRenderer,
-    nextElementId: 0,
+    ids: idAllocatorFor(renderer),
     eventHandlers: new Map(),
   }
   attachRoot(renderer, gpuixContainer)

--- a/packages/react/src/types/host.ts
+++ b/packages/react/src/types/host.ts
@@ -477,11 +477,16 @@ export type EventHandlerMap = Map<
   Map<string, (event: EventPayload) => void>
 >
 
-// One React root. Ids and event handlers stay on this object so two live
-// roots can both use id 1 without overwriting each other.
+export interface ElementIdAllocator {
+  nextElementId: number
+}
+
+// One React root. Event handlers stay on this object so two live roots
+// can both use id 1. Ids come from an allocator that lives with the
+// NativeRenderer, so a remount on the same renderer cannot reuse them.
 export interface Container {
   renderer: NativeRenderer
-  nextElementId: number
+  ids: ElementIdAllocator
   eventHandlers: EventHandlerMap
 }
 


### PR DESCRIPTION
**Harness:** OpenCode / Kimaki
**Agent:** build
**Model:** xai/grok-4.6

Follow-up to #16. Event maps stay per root. Ids now stay unique for the life of one `NativeRenderer`.

`bun --hot` remounts on the same window. If ids started at 1 again, a late native event from the old tree could hit the new handler.

Two `createTestRoot()` trees still both start at id `1`. Each one owns a renderer.

<details>
<summary>User prompts</summary>

1. ask oracle review

</details>