### PR TITLE
fix(native): deliver onClick from primary mouse-up

### DIFF
--- a/.changeset/fix-embedded-primary-clicks.md
+++ b/.changeset/fix-embedded-primary-clicks.md
@@ -1,0 +1,8 @@
+---
+'@gpuix/native': patch
+'@gpuix/react': patch
+---
+
+Deliver `onClick` from primary-button mouse-up for retained and custom native elements so embedded macOS windows receive clicks reliably.
+
+Fixes #41

--- a/README.md
+++ b/README.md
@@ -2046,8 +2046,8 @@ text imports no longer need a runtime flag.
 
 | Event | Props | Payload fields |
 |-------|-------|----------------|
-| Click | `onClick` | `x`, `y`, `clickCount`, `isRightClick`, `modifiers` — primary button only |
-| Aux click | `onAuxClick` | Same fields, for the non-primary buttons |
+| Click | `onClick` | `x`, `y`, `button`, `clickCount`, `isRightClick`, `modifiers` — primary button only |
+| Aux click | `onAuxClick` | `x`, `y`, `clickCount`, `isRightClick`, `modifiers` — non-primary buttons |
 | Mouse down | `onMouseDown` | `x`, `y`, `button`, `clickCount`, `modifiers` |
 | Mouse up | `onMouseUp` | `x`, `y`, `button`, `clickCount`, `modifiers` |
 | Mouse enter | `onMouseEnter` | `hovered` |
@@ -2097,8 +2097,8 @@ is one event per pointer move.
 Capture arms on the **left** button only. A right-button drag is not captured,
 so it ends when the pointer leaves the element.
 
-`onClick` is the primary button too, like the DOM. Use **`onAuxClick`** for the
-others, and read `event.isRightClick`. `onMouseDown` and `onMouseUp` see every
+`onClick` fires on primary-button mouse-up. Use **`onAuxClick`** for the others,
+and read `event.isRightClick`. `onMouseDown` and `onMouseUp` see every
 button through `event.button` (`0` left, `1` middle, `2` right).
 
 ## Supported Styles

--- a/packages/native/src/custom_elements/input.rs
+++ b/packages/native/src/custom_elements/input.rs
@@ -425,12 +425,17 @@ impl CustomElement for TextEditorElement {
         if ctx.events.contains("click") {
             let callback = ctx.event_callback.clone();
             let id = ctx.id;
-            editor = editor.on_click(move |event, _window, _cx| {
+            // Match retained hosts: GPUI's semantic click is unreliable under
+            // embedded AppKit pumping, so primary mouse-up is the click boundary.
+            editor = editor.on_mouse_up(MouseButton::Left, move |event, _window, _cx| {
                 emit_event_full(&callback, id, "click", |payload| {
-                    let (x, y) = crate::renderer::point_to_xy(event.position());
+                    let (x, y) = crate::renderer::point_to_xy(event.position);
                     payload.x = Some(x);
                     payload.y = Some(y);
-                    payload.modifiers = Some(event.modifiers().into());
+                    payload.button = Some(0);
+                    payload.click_count = Some(event.click_count as u32);
+                    payload.modifiers = Some(event.modifiers.into());
+                    payload.is_right_click = Some(false);
                 });
             });
         }

--- a/packages/native/src/custom_elements/mod.rs
+++ b/packages/native/src/custom_elements/mod.rs
@@ -144,13 +144,17 @@ pub(crate) fn wire_standard_events<E: gpui::StatefulInteractiveElement>(
         let callback = ctx.event_callback.clone();
         match event.as_str() {
             "click" => {
-                el = el.on_click(move |click, _window, _cx| {
+                // Match retained hosts: GPUI's semantic click is unreliable under
+                // embedded AppKit pumping, so primary mouse-up is the click boundary.
+                el = el.on_mouse_up(gpui::MouseButton::Left, move |mouse_event, _window, _cx| {
                     crate::renderer::emit_event_full(&callback, id, "click", |p| {
-                        let (x, y) = crate::renderer::point_to_xy(click.position());
+                        let (x, y) = crate::renderer::point_to_xy(mouse_event.position);
                         p.x = Some(x);
                         p.y = Some(y);
-                        p.click_count = Some(click.click_count() as u32);
-                        p.modifiers = Some(click.modifiers().into());
+                        p.button = Some(0);
+                        p.click_count = Some(mouse_event.click_count as u32);
+                        p.modifiers = Some(mouse_event.modifiers.into());
+                        p.is_right_click = Some(false);
                     });
                 });
             }

--- a/packages/native/src/renderer.rs
+++ b/packages/native/src/renderer.rs
@@ -4370,29 +4370,32 @@ pub(crate) fn build_host_container(
     }
 
     // Wire up events.
-    // Some events (on_hover, on_click) require a stateful element (.id()),
+    // Some events (on_hover, on_aux_click) require a stateful element (.id()),
     // which we already set above. Others (on_mouse_down, on_key_down) work
     // on any InteractiveElement.
+    if element.events.contains("click") {
+        let id = element.id;
+        let callback = ctx.event_callback.clone();
+        // GPUI's higher-level on_click gesture is not finalized by the
+        // embedded macOS pump. Bubble listeners run in reverse registration
+        // order, so attach click first to keep onMouseUp ahead of onClick.
+        el = el.on_mouse_up(gpui::MouseButton::Left, move |mouse_event, _window, _cx| {
+            emit_event_full(&callback, id, "click", |p| {
+                let (x, y) = point_to_xy(mouse_event.position);
+                p.x = Some(x);
+                p.y = Some(y);
+                p.button = Some(0);
+                p.modifiers = Some(mouse_event.modifiers.into());
+                p.click_count = Some(mouse_event.click_count as u32);
+                p.is_right_click = Some(false);
+            });
+        });
+    }
+
     for event_type in &element.events {
         let id = element.id;
         let callback = ctx.event_callback.clone();
         match event_type.as_str() {
-            // ── Click ────────────────────────────────────────────
-            // Primary button only, like the DOM. Right and middle clicks go to
-            // `onAuxClick`, and `onMouseDown` sees every button.
-            "click" => {
-                el = el.on_click(move |click_event, _window, _cx| {
-                    emit_event_full(&callback, id, "click", |p| {
-                        let (x, y) = point_to_xy(click_event.position());
-                        p.x = Some(x);
-                        p.y = Some(y);
-                        p.modifiers = Some(click_event.modifiers().into());
-                        p.click_count = Some(click_event.click_count() as u32);
-                        p.is_right_click = Some(click_event.is_right_click());
-                    });
-                });
-            }
-
             // ── Aux click (non-primary), like the DOM `auxclick` ──
             "auxClick" => {
                 el = el.on_aux_click(move |click_event, _window, _cx| {

--- a/packages/react/src/__tests__/events.test.tsx
+++ b/packages/react/src/__tests__/events.test.tsx
@@ -15,6 +15,7 @@ import { describe, it, expect, beforeEach } from "vitest"
 import React, { useState, useRef } from "react"
 import { createTestRoot, hasNativeTestRenderer } from "../testing"
 import { startFrameLoop } from "../reconciler/renderer.js"
+import { motion } from "../index"
 import type { EventPayload } from "@gpuix/native"
 import { expectScreenshotsDiffer, SHOTS_DIR } from "./test-utils"
 
@@ -165,6 +166,80 @@ describeNative("events", () => {
           "Count: 2",
         ]
       `)
+    })
+
+    it("synthesizes click only for the primary button", () => {
+      const received: string[] = []
+      testRoot.render(
+        <div
+          style={{ width: 200, height: 50 }}
+          onMouseDown={(event) => received.push(`down:${event.button}`)}
+          onMouseUp={(event) => received.push(`up:${event.button}`)}
+          onClick={(event) => received.push(`click:${event.button}:${event.isRightClick}`)}
+        />,
+      )
+
+      for (const button of [1, 2]) {
+        testRoot.renderer.nativeSimulateMouseDown(10, 10, button)
+        testRoot.renderer.nativeSimulateMouseUp(10, 10, button)
+      }
+      expect(received).toEqual(["down:1", "up:1", "down:2", "up:2"])
+
+      testRoot.renderer.nativeSimulateMouseDown(10, 10, 0)
+      testRoot.renderer.nativeSimulateMouseUp(10, 10, 0)
+      expect(received).toEqual([
+        "down:1",
+        "up:1",
+        "down:2",
+        "up:2",
+        "down:0",
+        "up:0",
+        "click:0:false",
+      ])
+    })
+
+    it("dispatches primary clicks from motion elements", () => {
+      let clicks = 0
+      testRoot.render(
+        <motion.div
+          initial={false}
+          animate={{ width: 200 }}
+          style={{ width: 200, height: 50 }}
+          onClick={() => {
+            clicks += 1
+          }}
+        />,
+      )
+
+      testRoot.renderer.nativeSimulateMouseDown(10, 10, 0)
+      testRoot.renderer.nativeSimulateMouseUp(10, 10, 0)
+      expect(clicks).toBe(1)
+      testRoot.renderer.nativeSimulateMouseDown(10, 10, 2)
+      testRoot.renderer.nativeSimulateMouseUp(10, 10, 2)
+      expect(clicks).toBe(1)
+    })
+
+    it("dispatches primary clicks from native custom elements", () => {
+      const clicks: EventPayload[] = []
+      testRoot.render(
+        <div style={{ display: "flex", padding: 20 }}>
+          <code
+            code="hello"
+            language="ts"
+            onClick={(event) => {
+              clicks.push(event)
+            }}
+          />
+        </div>,
+      )
+
+      testRoot.renderer.nativeSimulateMouseDown(30, 28, 0)
+      testRoot.renderer.nativeSimulateMouseUp(30, 28, 0)
+      expect(clicks).toHaveLength(1)
+      expect(clicks[0]).toMatchObject({ button: 0, isRightClick: false })
+      testRoot.renderer.nativeSimulateMouseDown(30, 28, 2)
+      testRoot.renderer.nativeSimulateMouseUp(30, 28, 2)
+      expect(clicks).toHaveLength(1)
     })
   })
 

--- a/packages/react/src/__tests__/input.test.tsx
+++ b/packages/react/src/__tests__/input.test.tsx
@@ -377,7 +377,9 @@ describeNative("native text editors", () => {
     expect(testRoot.renderer.getAllText()).toContain("Value: a")
   })
 
-  it("keeps click and keyboard events available", () => {
+  it("keeps primary click and keyboard events available", () => {
+    let click: EventPayload | undefined
+
     function TextInput() {
       const [clicks, setClicks] = useState(0)
       const [keys, setKeys] = useState(0)
@@ -386,7 +388,10 @@ describeNative("native text editors", () => {
           <input
             value=""
             style={{ width: 300, height: 40 }}
-            onClick={() => setClicks((count) => count + 1)}
+            onClick={(event) => {
+              click = event
+              setClicks((count) => count + 1)
+            }}
             onKeyDown={() => setKeys((count) => count + 1)}
           />
           <text>{`Events: ${clicks}/${keys}`}</text>
@@ -396,9 +401,15 @@ describeNative("native text editors", () => {
 
     testRoot.render(<TextInput />)
     const input = testRoot.renderer.findByType("input")[0]
-    testRoot.renderer.nativeSimulateClick(150, 20)
+    testRoot.renderer.nativeSimulateMouseDown(150, 20, 0)
+    testRoot.renderer.nativeSimulateMouseUp(150, 20, 0)
     testRoot.renderer.nativeSimulateKeyDown(input.id, "a")
 
+    expect(testRoot.renderer.getAllText()).toContain("Events: 1/1")
+    expect(click).toMatchObject({ button: 0, isRightClick: false })
+
+    testRoot.renderer.nativeSimulateMouseDown(150, 20, 2)
+    testRoot.renderer.nativeSimulateMouseUp(150, 20, 2)
     expect(testRoot.renderer.getAllText()).toContain("Events: 1/1")
   })
 })


### PR DESCRIPTION
## Summary

- deliver public `onClick` from primary-button mouse-up for retained hosts, motion hosts, standard native custom elements, and input/textarea
- preserve middle/right mouse and aux behavior while guaranteeing `onMouseUp` runs before `onClick`
- align click payloads and documentation, with focused native hit-testing regressions and a changeset

## Validation

- `cargo fmt --manifest-path packages/native/Cargo.toml -- --check`
- `cargo test --lib --features test-support,gpui_macos/runtime_shaders` — 221 passed
- native release/test-support N-API build with runtime shaders
- `bun run test` in `packages/react` — 373 passed
- `bun run build` in `packages/react`
- `bun run test` in `examples` — 47 passed
- `bun run typecheck` in `example-app`
- Grok 4.6 final review — APPROVE

Fixes #41
